### PR TITLE
fix: keep completed-but-unverified chores visible after day rollover

### DIFF
--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -958,16 +958,17 @@ async def verify_chore(
         select(ChoreAssignment)
         .where(
             ChoreAssignment.chore_id == chore_id,
-            ChoreAssignment.date == today,
             ChoreAssignment.status == AssignmentStatus.completed,
         )
         .options(selectinload(ChoreAssignment.chore))
+        .order_by(ChoreAssignment.date.desc())
+        .limit(1)
     )
     assignment = result.scalar_one_or_none()
     if assignment is None:
         raise HTTPException(
             status_code=404,
-            detail="No completed assignment found to verify for this chore today",
+            detail="No completed assignment found to verify for this chore",
         )
 
     chore = assignment.chore
@@ -1151,17 +1152,18 @@ async def uncomplete_chore(
     result = await db.execute(
         select(ChoreAssignment).where(
             ChoreAssignment.chore_id == chore_id,
-            ChoreAssignment.date == today,
             ChoreAssignment.status.in_(
                 [AssignmentStatus.completed, AssignmentStatus.verified]
             ),
         )
+        .order_by(ChoreAssignment.date.desc())
+        .limit(1)
     )
     assignment = result.scalar_one_or_none()
     if assignment is None:
         raise HTTPException(
             status_code=404,
-            detail="No completed assignment found to undo for this chore today",
+            detail="No completed assignment found to undo for this chore",
         )
 
     assigned_user_id = assignment.user_id

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import HTMLResponse
-from sqlalchemy import select, func
+from sqlalchemy import select, func, or_, and_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -292,13 +292,19 @@ async def get_kid_detail(
         .join(Chore, ChoreAssignment.chore_id == Chore.id)
         .where(
             ChoreAssignment.user_id == kid_id,
-            ChoreAssignment.date == today,
             Chore.is_active == True,
+            or_(
+                ChoreAssignment.date == today,
+                and_(
+                    ChoreAssignment.date < today,
+                    ChoreAssignment.status == AssignmentStatus.completed,
+                ),
+            ),
         )
         .options(
             _chore_with_category_loader(),
         )
-        .order_by(ChoreAssignment.status, Chore.title)
+        .order_by(ChoreAssignment.date.desc(), ChoreAssignment.status, Chore.title)
     )
     assignments = result.scalars().all()
 
@@ -637,6 +643,7 @@ def _build_kid_assignment(a: ChoreAssignment) -> dict:
     return {
         "id": a.id,
         "chore_id": a.chore_id,
+        "date": a.date.isoformat() if a.date else None,
         "status": a.status.value,
         "completed_at": a.completed_at.isoformat() if a.completed_at else None,
         "verified_at": a.verified_at.isoformat() if a.verified_at else None,

--- a/frontend/src/pages/KidQuests.jsx
+++ b/frontend/src/pages/KidQuests.jsx
@@ -23,6 +23,17 @@ const STATUS_CONFIG = {
   skipped: { label: 'Skipped', color: 'text-muted/50', icon: SkipForward },
 };
 
+function formatAssignmentDate(dateStr) {
+  if (!dateStr) return null;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const d = new Date(dateStr + 'T00:00:00');
+  const diffDays = Math.round((today - d) / 86400000);
+  if (diffDays === 0) return null;
+  if (diffDays === 1) return 'from yesterday';
+  return `from ${d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`;
+}
+
 export default function KidQuests() {
   const { kidId } = useParams();
   const navigate = useNavigate();
@@ -108,8 +119,13 @@ export default function KidQuests() {
   if (!data) return null;
 
   const { kid, assignments } = data;
-  const completedCount = assignments.filter(
+  const today = new Date().toISOString().slice(0, 10);
+  const todayAssignments = assignments.filter((a) => a.date === today);
+  const completedCount = todayAssignments.filter(
     (a) => a.status === 'completed' || a.status === 'verified'
+  ).length;
+  const pendingReviewCount = assignments.filter(
+    (a) => a.status === 'completed' && a.date !== today
   ).length;
 
   return (
@@ -140,7 +156,12 @@ export default function KidQuests() {
               )}
             </div>
             <p className="text-muted text-xs mt-1">
-              {completedCount}/{assignments.length} quests done today
+              {completedCount}/{todayAssignments.length} quests done today
+              {pendingReviewCount > 0 && (
+                <span className="ml-2 text-gold">
+                  · {pendingReviewCount} awaiting approval
+                </span>
+              )}
             </p>
           </div>
         </div>
@@ -166,6 +187,7 @@ export default function KidQuests() {
           {assignments.map((a, idx) => {
             const cfg = STATUS_CONFIG[a.status] || STATUS_CONFIG.pending;
             const StatusIcon = cfg.icon;
+            const dateLabel = formatAssignmentDate(a.date);
             const isCompleted = a.status === 'completed';
             const isVerified = a.status === 'verified';
             const verifyKey = `verify-${a.chore_id}`;
@@ -211,6 +233,9 @@ export default function KidQuests() {
                         <StatusIcon size={12} />
                         {cfg.label}
                       </span>
+                      {dateLabel && (
+                        <span className="text-muted text-xs italic">{dateLabel}</span>
+                      )}
                     </div>
                   </div>
 


### PR DESCRIPTION
## Summary

Fixes [finalbillybong/ChoreQuest#110](https://github.com/finalbillybong/ChoreQuest/issues/110) — chores completed by a kid but not yet approved by a parent were disappearing at midnight.

**Root cause:** every backend query filtering assignments used `ChoreAssignment.date == today`, so anything completed on a prior day became invisible the next morning.

**Changes:**
- **`backend/routers/stats.py`** — `get_kid_detail` now fetches *all* of today's assignments **plus** any prior-day assignments still in `completed` (awaiting-approval) state. Also adds a `date` field to each assignment in the response.
- **`backend/routers/chores.py`** — `verify_chore` and `uncomplete_chore` no longer filter by `date == today`; both now operate on the most-recent matching assignment (ordered `date DESC`), so parents can approve or reject quests completed on a previous day.
- **`frontend/src/pages/KidQuests.jsx`** — summary counter now correctly counts today's quests separately; cards for carry-over quests display an italic *"from yesterday"* / *"from [date]"* label so parents know the context.

## Test plan

- [ ] Complete a chore as a kid, do **not** approve it, then advance the system date by one day and reload the parent's quest view — the chore should still appear with status "Awaiting Approval"
- [ ] Verify (approve) the carried-over chore — it should update correctly and points should be awarded
- [ ] Reject (uncomplete) the carried-over chore — it should revert to pending
- [ ] Confirm that today's normal pending/completed/verified/skipped quests are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)