### PR TITLE
fix: multi-kid verify crash, notification navigation, and late completion grace period

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -298,13 +298,14 @@ async def get_feature_settings(
     _user: User = Depends(get_current_user),
 ):
     """Get feature toggle settings (accessible by any authenticated user)."""
-    feature_keys = ["leaderboard_enabled", "spin_wheel_enabled", "chore_trading_enabled"]
+    feature_keys = ["leaderboard_enabled", "spin_wheel_enabled", "chore_trading_enabled", "grace_period_days"]
     result = await db.execute(
         select(AppSetting).where(AppSetting.key.in_(feature_keys))
     )
     settings_list = result.scalars().all()
     # Return with defaults for any missing keys
-    features = {k: "true" for k in feature_keys}
+    features = {k: "true" for k in feature_keys if k != "grace_period_days"}
+    features["grace_period_days"] = "1"
     for s in settings_list:
         features[s.key] = s.value
     return features

--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -948,18 +948,23 @@ async def complete_chore(
 @router.post("/{chore_id}/verify", response_model=AssignmentResponse)
 async def verify_chore(
     chore_id: int,
+    kid_id: int | None = Query(None),
     db: AsyncSession = Depends(get_db),
     user: User = Depends(require_parent),
 ):
     today = date.today()
     now = datetime.now(timezone.utc)
 
+    filters = [
+        ChoreAssignment.chore_id == chore_id,
+        ChoreAssignment.status == AssignmentStatus.completed,
+    ]
+    if kid_id is not None:
+        filters.append(ChoreAssignment.user_id == kid_id)
+
     result = await db.execute(
         select(ChoreAssignment)
-        .where(
-            ChoreAssignment.chore_id == chore_id,
-            ChoreAssignment.status == AssignmentStatus.completed,
-        )
+        .where(*filters)
         .options(selectinload(ChoreAssignment.chore))
         .order_by(ChoreAssignment.date.desc())
         .limit(1)
@@ -1143,19 +1148,25 @@ async def verify_chore(
 @router.post("/{chore_id}/uncomplete", response_model=AssignmentResponse)
 async def uncomplete_chore(
     chore_id: int,
+    kid_id: int | None = Query(None),
     db: AsyncSession = Depends(get_db),
     user: User = Depends(require_parent),
 ):
     today = date.today()
     now = datetime.now(timezone.utc)
 
+    filters = [
+        ChoreAssignment.chore_id == chore_id,
+        ChoreAssignment.status.in_(
+            [AssignmentStatus.completed, AssignmentStatus.verified]
+        ),
+    ]
+    if kid_id is not None:
+        filters.append(ChoreAssignment.user_id == kid_id)
+
     result = await db.execute(
-        select(ChoreAssignment).where(
-            ChoreAssignment.chore_id == chore_id,
-            ChoreAssignment.status.in_(
-                [AssignmentStatus.completed, AssignmentStatus.verified]
-            ),
-        )
+        select(ChoreAssignment)
+        .where(*filters)
         .order_by(ChoreAssignment.date.desc())
         .limit(1)
     )

--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -936,8 +936,8 @@ async def complete_chore(
             type=NotificationType.chore_completed,
             title="Quest Awaiting Approval",
             message=f"{user.display_name} completed '{chore.title}' - tap to approve (+{chore.points} XP)",
-            reference_type="chore_assignment",
-            reference_id=assignment.id,
+            reference_type="kid_quest",
+            reference_id=user.id,
         ))
     await db.commit()
 

--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import selectinload
 
 from backend.database import get_db
 from backend.models import (
+    AppSetting,
     Chore,
     ChoreAssignment,
     ChoreAssignmentRule,
@@ -844,21 +845,31 @@ async def complete_chore(
     today = date.today()
     now = datetime.now(timezone.utc)
 
+    grace_result = await db.execute(
+        select(AppSetting).where(AppSetting.key == "grace_period_days")
+    )
+    grace_setting = grace_result.scalar_one_or_none()
+    grace_days = int(grace_setting.value) if grace_setting else 1
+    earliest = today - timedelta(days=grace_days)
+
     result = await db.execute(
         select(ChoreAssignment)
         .where(
             ChoreAssignment.chore_id == chore_id,
             ChoreAssignment.user_id == user.id,
-            ChoreAssignment.date == today,
+            ChoreAssignment.date >= earliest,
+            ChoreAssignment.date <= today,
             ChoreAssignment.status == AssignmentStatus.pending,
         )
         .options(selectinload(ChoreAssignment.chore))
+        .order_by(ChoreAssignment.date.desc())
+        .limit(1)
     )
     assignment = result.scalar_one_or_none()
     if assignment is None:
         raise HTTPException(
             status_code=404,
-            detail="No pending assignment found for this chore today",
+            detail="No pending assignment found for this chore within the grace period",
         )
 
     chore = assignment.chore

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -243,7 +243,13 @@ export default function Layout({ children }) {
                         return (
                           <div
                             key={n.id}
-                            onClick={() => { if (!n.is_read && !isTrade) markRead(n.id); }}
+                            onClick={() => {
+                              if (!n.is_read && !isTrade) markRead(n.id);
+                              if (n.reference_type === 'kid_quest' && n.reference_id) {
+                                setShowNotifs(false);
+                                navigate(`/kids/${n.reference_id}`);
+                              }
+                            }}
                             className={`w-full text-left px-4 py-3 border-b border-border/50 hover:bg-surface-raised transition-colors cursor-pointer ${
                               !n.is_read ? 'bg-accent/5' : ''
                             }`}

--- a/frontend/src/hooks/useSettings.jsx
+++ b/frontend/src/hooks/useSettings.jsx
@@ -5,6 +5,7 @@ const SettingsContext = createContext({
   leaderboard_enabled: true,
   spin_wheel_enabled: true,
   chore_trading_enabled: true,
+  grace_period_days: 1,
 });
 
 export function SettingsProvider({ children }) {
@@ -12,6 +13,7 @@ export function SettingsProvider({ children }) {
     leaderboard_enabled: true,
     spin_wheel_enabled: true,
     chore_trading_enabled: true,
+    grace_period_days: 1,
   });
 
   const fetchFeatures = useCallback(async () => {
@@ -21,6 +23,7 @@ export function SettingsProvider({ children }) {
         leaderboard_enabled: data.leaderboard_enabled !== 'false',
         spin_wheel_enabled: data.spin_wheel_enabled !== 'false',
         chore_trading_enabled: data.chore_trading_enabled !== 'false',
+        grace_period_days: parseInt(data.grace_period_days ?? '1', 10),
       });
     } catch {
       // If fetch fails, keep defaults (all enabled)

--- a/frontend/src/pages/KidDashboard.jsx
+++ b/frontend/src/pages/KidDashboard.jsx
@@ -74,12 +74,13 @@ const cardVariants = {
 
 export default function KidDashboard() {
   const { user, updateUser } = useAuth();
-  const { spin_wheel_enabled } = useSettings();
+  const { spin_wheel_enabled, grace_period_days } = useSettings();
   const { colorTheme } = useTheme();
   const navigate = useNavigate();
 
   // data state
   const [assignments, setAssignments] = useState([]);
+  const [overdueAssignments, setOverdueAssignments] = useState([]);
   const [chores, setChores] = useState([]);
   const [spinAvailability, setSpinAvailability] = useState(null);
   const [myStats, setMyStats] = useState(null);
@@ -114,9 +115,17 @@ export default function KidDashboard() {
       const monday = getMondayOfThisWeek();
       const today = todayISO();
 
+      // Also fetch the previous week if the grace period might reach back that far
+      const prevMonday = (() => {
+        const d = new Date(monday);
+        d.setDate(d.getDate() - 7);
+        return d.toISOString().slice(0, 10);
+      })();
+
       const promises = [
         api('/api/chores'),
         api(`/api/calendar?week_start=${monday}`),
+        grace_period_days > 0 ? api(`/api/calendar?week_start=${prevMonday}`) : Promise.resolve(null),
       ];
       if (spin_wheel_enabled) {
         promises.push(api('/api/spin/availability'));
@@ -126,8 +135,9 @@ export default function KidDashboard() {
       const results = await Promise.all(promises);
       const choresRes = results[0];
       const calendarRes = results[1];
-      const spinRes = spin_wheel_enabled ? results[2] : null;
-      const statsRes = results[spin_wheel_enabled ? 3 : 2];
+      const prevCalendarRes = results[2];
+      const spinRes = spin_wheel_enabled ? results[3] : null;
+      const statsRes = results[spin_wheel_enabled ? 4 : 3];
       if (statsRes) {
         setMyStats(statsRes);
         if (statsRes.interactions_remaining != null) {
@@ -142,13 +152,34 @@ export default function KidDashboard() {
       const todayAssignments = allToday.filter((a) => a.user_id === user?.id);
       setAssignments(todayAssignments);
 
+      // Collect pending assignments from past days within the grace window
+      if (grace_period_days > 0) {
+        const overdue = [];
+        const allDays = {
+          ...(calendarRes.days || {}),
+          ...(prevCalendarRes?.days || {}),
+        };
+        for (let d = 1; d <= grace_period_days; d++) {
+          const dt = new Date(today);
+          dt.setDate(dt.getDate() - d);
+          const dayStr = dt.toISOString().slice(0, 10);
+          const dayAssignments = (allDays[dayStr] || []).filter(
+            (a) => a.user_id === user?.id && a.status === 'pending'
+          );
+          overdue.push(...dayAssignments.map((a) => ({ ...a, _overdue_date: dayStr })));
+        }
+        setOverdueAssignments(overdue);
+      } else {
+        setOverdueAssignments([]);
+      }
+
       setSpinAvailability(spinRes);
     } catch (err) {
       setError(err.message || 'Failed to load quest data');
     } finally {
       setLoading(false);
     }
-  }, [user?.id, spin_wheel_enabled]);
+  }, [user?.id, spin_wheel_enabled, grace_period_days]);
 
   useEffect(() => {
     fetchData();
@@ -299,6 +330,68 @@ export default function KidDashboard() {
         <div className="game-panel p-3 flex items-center gap-2 border-crimson/30 text-crimson text-sm">
           <AlertTriangle size={16} />
           <span>{error}</span>
+        </div>
+      )}
+
+      {/* ── Overdue quests (grace period) ── */}
+      {overdueAssignments.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-crimson text-xs font-semibold px-1 flex items-center gap-1">
+            <AlertTriangle size={12} />
+            Forgotten Quests — mark these done if you completed them!
+          </p>
+          {overdueAssignments.map((assignment, idx) => {
+            const chore = assignment.chore;
+            if (!chore) return null;
+            const diff = difficultyLabel(chore.difficulty);
+            const categoryColor = chore.category?.colour || '#14b8a6';
+            const daysAgo = Math.round(
+              (new Date().setHours(0,0,0,0) - new Date(assignment._overdue_date + 'T00:00:00')) / 86400000
+            );
+            return (
+              <motion.div
+                key={assignment.id}
+                className="game-panel p-4 border-crimson/30 cursor-pointer hover:border-crimson/50 transition-all"
+                variants={cardVariants}
+                initial="hidden"
+                animate="visible"
+                custom={idx}
+                onClick={() => navigate('/chores')}
+              >
+                <div className="flex items-start gap-3">
+                  <div className="mt-0.5 w-1 h-12 rounded-full flex-shrink-0 bg-crimson/60" />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between gap-2 mb-1.5">
+                      <h3 className="text-cream text-sm font-semibold truncate">
+                        {themedTitle(chore.title, colorTheme)}
+                      </h3>
+                      <span className="text-crimson text-[10px] font-bold flex-shrink-0 bg-crimson/10 border border-crimson/30 px-1.5 py-0.5 rounded">
+                        {daysAgo === 1 ? 'Yesterday' : `${daysAgo}d ago`}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="inline-flex items-center gap-1 text-gold text-xs font-semibold">
+                        <Star size={12} fill="currentColor" />
+                        {chore.points} XP
+                      </span>
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-semibold border ${diff.color}`}>
+                        {diff.text}
+                      </span>
+                      {chore.category?.name && (
+                        <span className="text-muted text-xs">{chore.category.name}</span>
+                      )}
+                      {chore.requires_photo && (
+                        <span className="inline-flex items-center gap-1 text-muted text-xs">
+                          <Camera size={10} />
+                          Photo
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </motion.div>
+            );
+          })}
         </div>
       )}
 

--- a/frontend/src/pages/KidQuests.jsx
+++ b/frontend/src/pages/KidQuests.jsx
@@ -74,7 +74,7 @@ export default function KidQuests() {
     const key = `verify-${choreId}`;
     setActionBusy(key, true);
     try {
-      await api(`/api/chores/${choreId}/verify`, { method: 'POST' });
+      await api(`/api/chores/${choreId}/verify?kid_id=${kidId}`, { method: 'POST' });
       await fetchData();
     } catch (err) {
       setError(err.message || 'Failed to verify quest');
@@ -87,7 +87,7 @@ export default function KidQuests() {
     const key = `reject-${choreId}`;
     setActionBusy(key, true);
     try {
-      await api(`/api/chores/${choreId}/uncomplete`, { method: 'POST' });
+      await api(`/api/chores/${choreId}/uncomplete?kid_id=${kidId}`, { method: 'POST' });
       await fetchData();
     } catch (err) {
       setError(err.message || 'Failed to reject quest');

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -229,6 +229,27 @@ export default function Settings() {
             />
           </div>
 
+          {/* Grace period */}
+          <div className="game-panel p-4">
+            <h2 className="text-cream text-sm font-semibold mb-3">
+              Late Completion Grace Period
+            </h2>
+            <p className="text-muted text-xs mb-3">
+              Number of days kids can mark a past quest as done (0 = today only, 1 = yesterday allowed, etc.).
+            </p>
+            <input
+              type="number"
+              min={0}
+              max={7}
+              value={settings.grace_period_days ?? 1}
+              onChange={(e) => {
+                const val = Math.min(7, Math.max(0, parseInt(e.target.value, 10) || 0));
+                updateSetting('grace_period_days', val);
+              }}
+              className="field-input max-w-[120px]"
+            />
+          </div>
+
           {/* Save button */}
           <button
             onClick={saveSettings}


### PR DESCRIPTION
## Summary

Three fixes and one new feature built on top of the previously merged PR.

### Fix — [#109](https://github.com/finalbillybong/ChoreQuest/issues/109) Two kids complete same chore → 500 error
`verify` and `uncomplete` endpoints now accept a `?kid_id=` param. The frontend always passes the kid's ID so the right assignment is targeted. No more `MultipleResultsFound` crash.

### Fix — Tapping "tap to approve" notification did nothing
The notification `onClick` only called `markRead()` with no navigation. Also, the stored `reference_id` was the assignment ID — useless for routing. Now `chore_completed` notifications store `reference_type="kid_quest"` and `reference_id=kid's user ID`, and the panel navigates to `/kids/{id}` on tap.

### Feat — Grace period for late chore completion
Kids sometimes finish chores after losing screen time. A configurable grace period (default: 1 day, settable 0–7 in Settings) lets them mark past-day assignments done.
- Backend reads `grace_period_days` from app settings in `complete_chore`
- Kid dashboard shows a red "Forgotten Quests" section for overdue pending assignments with a "Yesterday" / "Xd ago" badge
- Settings page has a new "Late Completion Grace Period" input

## Test plan
- [ ] Two kids complete the same chore → parent can approve each one individually without errors
- [ ] Parent receives "tap to approve" notification → tapping navigates to that kid's quest page
- [ ] Kid has a pending chore from yesterday → it appears in "Forgotten Quests" on dashboard and can be submitted
- [ ] Set grace period to 0 in Settings → forgotten quests section disappears, past-day completion blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)