### PR TITLE
fix: notification tap works for old and new chore_completed notifications

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -248,6 +248,9 @@ export default function Layout({ children }) {
                               if (n.reference_type === 'kid_quest' && n.reference_id) {
                                 setShowNotifs(false);
                                 navigate(`/kids/${n.reference_id}`);
+                              } else if (n.type === 'chore_completed') {
+                                setShowNotifs(false);
+                                navigate('/');
                               }
                             }}
                             className={`w-full text-left px-4 py-3 border-b border-border/50 hover:bg-surface-raised transition-colors cursor-pointer ${


### PR DESCRIPTION
## Summary

The previous notification tap fix only worked for new notifications (those created after the last deploy). Existing notifications in the DB have `reference_type="chore_assignment"` so the `kid_quest` check never matched and nothing happened.

Added a fallback: any `chore_completed` notification without the new `reference_type` now navigates to the parent dashboard (`/`) where pending approvals are visible.

Going forward, new notifications use `reference_type="kid_quest"` and navigate directly to the specific kid's quest page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)