### PR TITLE
feat/fix: add chores to library, fix templates route, fix timezone bug

### DIFF
--- a/frontend/src/pages/Chores.jsx
+++ b/frontend/src/pages/Chores.jsx
@@ -85,7 +85,10 @@ function getMondayOfThisWeek() {
   const diff = day === 0 ? -6 : 1 - day;
   const monday = new Date(now);
   monday.setDate(now.getDate() + diff);
-  return monday.toISOString().slice(0, 10);
+  const y = monday.getFullYear();
+  const m = String(monday.getMonth() + 1).padStart(2, '0');
+  const d = String(monday.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }
 
 function todayISO() {

--- a/frontend/src/pages/KidDashboard.jsx
+++ b/frontend/src/pages/KidDashboard.jsx
@@ -38,7 +38,10 @@ function getMondayOfThisWeek() {
   const diff = day === 0 ? -6 : 1 - day;
   const monday = new Date(now);
   monday.setDate(now.getDate() + diff);
-  return monday.toISOString().slice(0, 10);
+  const y = monday.getFullYear();
+  const m = String(monday.getMonth() + 1).padStart(2, '0');
+  const d = String(monday.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }
 
 function todayISO() {


### PR DESCRIPTION
## Summary

- **feat:** 16 new quests added to `DEFAULT_QUESTS` so they appear in the chores library at `/chores` without needing the template picker
- **fix:** `GET /templates` route moved before `GET /{chore_id}` — template picker was always broken due to FastAPI route shadowing (issue #12)
- **fix:** `getMondayOfThisWeek()` now uses local date formatting instead of `toISOString()` — prevents `400 week_start must be a Monday` error near UTC midnight (issue #13)

## Test plan

- [ ] Rebuild container and verify 16 new quests appear at `/chores`
- [ ] Open New Quest modal and confirm templates load
- [ ] Confirm no `week_start` errors on kid dashboard or calendar

🤖 Generated with [Claude Code](https://claude.com/claude-code)