### PR TITLE
fix: kids can now complete daily quests — UTC date bug across all pages

### DIFF
--- a/frontend/src/pages/Calendar.jsx
+++ b/frontend/src/pages/Calendar.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { api } from '../api/client';
 import { useAuth } from '../hooks/useAuth';
 import { useSettings } from '../hooks/useSettings';
+import { toLocalISO, todayLocalISO } from '../utils/dates';
 import { useTheme } from '../hooks/useTheme';
 import { themedTitle } from '../utils/questThemeText';
 import Modal from '../components/Modal';
@@ -20,19 +21,19 @@ import {
 } from 'lucide-react';
 
 function toISO(date) {
-  return date.toISOString().slice(0, 10);
+  return toLocalISO(date);
 }
 
 function addDays(dateStr, n) {
   const d = new Date(dateStr + 'T00:00:00');
   d.setDate(d.getDate() + n);
-  return d.toISOString().slice(0, 10);
+  return toLocalISO(d);
 }
 
 const SHORT_DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 function statusStyle(assignment, dayStr) {
-  const today = new Date().toISOString().slice(0, 10);
+  const today = todayLocalISO();
 
   if (assignment.status === 'verified') {
     return {

--- a/frontend/src/pages/Chores.jsx
+++ b/frontend/src/pages/Chores.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../api/client';
 import { useAuth } from '../hooks/useAuth';
+import { toLocalISO } from '../utils/dates';
 import { useTheme } from '../hooks/useTheme';
 import { themedTitle, themedDescription } from '../utils/questThemeText';
 import Modal from '../components/Modal';
@@ -92,7 +93,7 @@ function getMondayOfThisWeek() {
 }
 
 function todayISO() {
-  return new Date().toISOString().slice(0, 10);
+  return toLocalISO(new Date());
 }
 
 export default function Chores() {

--- a/frontend/src/pages/KidDashboard.jsx
+++ b/frontend/src/pages/KidDashboard.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { toLocalISO, todayLocalISO } from '../utils/dates';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Star,
@@ -45,7 +46,7 @@ function getMondayOfThisWeek() {
 }
 
 function todayISO() {
-  return new Date().toISOString().slice(0, 10);
+  return todayLocalISO();
 }
 
 function difficultyLabel(difficulty) {
@@ -120,9 +121,9 @@ export default function KidDashboard() {
 
       // Also fetch the previous week if the grace period might reach back that far
       const prevMonday = (() => {
-        const d = new Date(monday);
+        const d = new Date(monday + 'T00:00:00');
         d.setDate(d.getDate() - 7);
-        return d.toISOString().slice(0, 10);
+        return toLocalISO(d);
       })();
 
       const promises = [
@@ -163,9 +164,9 @@ export default function KidDashboard() {
           ...(prevCalendarRes?.days || {}),
         };
         for (let d = 1; d <= grace_period_days; d++) {
-          const dt = new Date(today);
+          const dt = new Date(today + 'T00:00:00');
           dt.setDate(dt.getDate() - d);
-          const dayStr = dt.toISOString().slice(0, 10);
+          const dayStr = toLocalISO(dt);
           const dayAssignments = (allDays[dayStr] || []).filter(
             (a) => a.user_id === user?.id && a.status === 'pending'
           );

--- a/frontend/src/pages/KidQuests.jsx
+++ b/frontend/src/pages/KidQuests.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { todayLocalISO } from '../utils/dates';
 import {
   Loader2,
   Star,
@@ -119,7 +120,7 @@ export default function KidQuests() {
   if (!data) return null;
 
   const { kid, assignments } = data;
-  const today = new Date().toISOString().slice(0, 10);
+  const today = todayLocalISO();
   const todayAssignments = assignments.filter((a) => a.date === today);
   const completedCount = todayAssignments.filter(
     (a) => a.status === 'completed' || a.status === 'verified'

--- a/frontend/src/pages/ParentDashboard.jsx
+++ b/frontend/src/pages/ParentDashboard.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { todayLocalISO } from '../utils/dates';
 import {
   Flame,
   Star,
@@ -54,7 +55,7 @@ export default function ParentDashboard() {
 
       setFamilyStats(familyRes);
 
-      const today = new Date().toISOString().slice(0, 10);
+      const today = todayLocalISO();
       const todayAssignments = (calendarRes.days && calendarRes.days[today]) || [];
       const needsVerification = todayAssignments.filter(
         (a) => a.status === 'completed'

--- a/frontend/src/utils/dates.js
+++ b/frontend/src/utils/dates.js
@@ -1,0 +1,12 @@
+/** Format a Date object as YYYY-MM-DD using LOCAL time (not UTC). */
+export function toLocalISO(date = new Date()) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/** Today's date as YYYY-MM-DD in local time. */
+export function todayLocalISO() {
+  return toLocalISO(new Date());
+}


### PR DESCRIPTION
## Problem

Kids could see their daily quests on the `/chores` page but had no Complete button. The parent dashboard verification queue and kid quest counts were also silently wrong.

**Root cause:** `toISOString()` returns the date in UTC, but the calendar API keys assignments by local date. When a user is in a non-UTC timezone, these mismatched — `calendarRes.days[today]` returned nothing, so `assignmentStatusMap` was empty and `isPending` was never true.

This is the same class of bug as the earlier "week_start must be a Monday" fix, but more widespread.

## Fix

Added `src/utils/dates.js` with `toLocalISO()` and `todayLocalISO()` helpers. Replaced all `toISOString().slice(0, 10)` calls used for date key lookups with local date formatting in:

- `frontend/src/pages/Chores.jsx` — **critical: Complete button now appears**
- `frontend/src/pages/KidDashboard.jsx` — today's assignments + overdue day range
- `frontend/src/pages/ParentDashboard.jsx` — verification queue
- `frontend/src/pages/KidQuests.jsx` — today's assignment count
- `frontend/src/pages/Calendar.jsx` — `toISO()`, `addDays()`, `statusStyle()`

## Test plan

- [ ] Kid logs in, goes to `/chores`, sees Complete button on assigned daily quests
- [ ] Parent dashboard shows correct verification queue
- [ ] Calendar highlights today correctly
- [ ] Run `./run-e2e.sh` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)