### PR TITLE
fix: patch remaining UTC date bugs and null guard

### DIFF
--- a/frontend/src/components/VacationSettings.jsx
+++ b/frontend/src/components/VacationSettings.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { api } from '../api/client';
+import { todayLocalISO } from '../utils/dates';
 import { Palmtree, Trash2, Plus, Loader2 } from 'lucide-react';
 
 export default function VacationSettings() {
@@ -55,7 +56,7 @@ export default function VacationSettings() {
     }
   };
 
-  const today = new Date().toISOString().slice(0, 10);
+  const today = todayLocalISO();
 
   return (
     <div className="game-panel p-5">

--- a/frontend/src/pages/Calendar.jsx
+++ b/frontend/src/pages/Calendar.jsx
@@ -160,7 +160,7 @@ export default function Calendar() {
     setTradeModal(true);
     try {
       const data = await api('/api/stats/kids');
-      const kids = (data || []).filter((k) => k.id !== user.id);
+      const kids = (data || []).filter((k) => k.id !== user?.id);
       setFamilyKids(kids);
     } catch {
       setFamilyKids([]);

--- a/frontend/src/pages/ChoreDetail.jsx
+++ b/frontend/src/pages/ChoreDetail.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { api } from '../api/client';
 import { useAuth } from '../hooks/useAuth';
 import { useTheme } from '../hooks/useTheme';
+import { todayLocalISO } from '../utils/dates';
 import { themedTitle, themedDescription } from '../utils/questThemeText';
 import {
   ArrowLeft,
@@ -311,7 +312,7 @@ export default function ChoreDetail() {
 
   // Determine today's assignment
   const assignments = chore.assignments || chore.history || [];
-  const today = new Date().toISOString().split('T')[0];
+  const today = todayLocalISO();
   const todayAssignment = assignments.find(
     (a) => a.date === today || a.assigned_date === today || a.due_date === today
   );

--- a/frontend/src/pages/Events.jsx
+++ b/frontend/src/pages/Events.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { api } from '../api/client';
+import { toLocalISO } from '../utils/dates';
 import { useAuth } from '../hooks/useAuth';
 import Modal from '../components/Modal';
 import {
@@ -20,7 +21,7 @@ function formatDate(iso) {
 
 function toInputDate(iso) {
   if (!iso) return '';
-  return new Date(iso).toISOString().slice(0, 10);
+  return toLocalISO(new Date(iso));
 }
 
 export default function Events() {
@@ -101,8 +102,8 @@ export default function Events() {
         title: title.trim(),
         description: description.trim() || null,
         multiplier: mult,
-        start_date: new Date(startDate + 'T00:00:00').toISOString(),
-        end_date: new Date(endDate + 'T23:59:59').toISOString(),
+        start_date: startDate,
+        end_date: endDate,
       };
 
       if (editing) {

--- a/frontend/src/pages/KidDashboard.jsx
+++ b/frontend/src/pages/KidDashboard.jsx
@@ -210,8 +210,8 @@ export default function KidDashboard() {
       await api(`/api/chores/${assignment.chore_id}/complete`, { method: 'POST' });
       setShowConfetti(true);
       await fetchData();
-    } catch (err) {
-      // ignore — e.g. photo required; let backend surface it silently
+    } catch {
+      await fetchData();
     } finally {
       setCompletingOverdue(null);
     }


### PR DESCRIPTION
## Summary

- **VacationSettings.jsx**: `new Date().toISOString().slice(0,10)` → `todayLocalISO()` — fixes vacation min-date being off by a day after 7pm CT
- **ChoreDetail.jsx**: same fix for today's assignment status lookup
- **Events.jsx**: `toInputDate()` now uses `toLocalISO()`, and event start/end dates are sent to the backend as plain `YYYY-MM-DD` strings instead of UTC ISO timestamps — prevents bonus XP events from being off by a day
- **Calendar.jsx**: `user.id` → `user?.id` to guard against null user during trade modal load
- **KidDashboard.jsx** `handleCompleteOverdue`: confetti no longer fires on API failure; data is refreshed either way so the quest shows its real state

## Test plan

- [ ] Create a vacation period — verify the min selectable date matches today's local date after 7pm CT
- [ ] Create a bonus XP event — verify start/end dates save correctly in America/Chicago timezone
- [ ] Open a quest detail page — verify today's assignment badge shows correct status
- [ ] Trigger overdue quest complete failure (e.g. requires photo) — verify no confetti, quest stays incomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)