### PR TITLE
fix: leaderboard weekly XP uses local date not UTC

### DIFF
--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -390,8 +390,8 @@ async def get_leaderboard(
         .where(
             PointTransaction.user_id.in_(list(kid_map.keys())),
             PointTransaction.amount > 0,
-            func.date(PointTransaction.created_at) >= monday,
-            func.date(PointTransaction.created_at) <= sunday,
+            func.date(func.datetime(PointTransaction.created_at, 'localtime')) >= monday,
+            func.date(func.datetime(PointTransaction.created_at, 'localtime')) <= sunday,
         )
         .group_by(PointTransaction.user_id)
         .order_by(func.sum(PointTransaction.amount).desc())


### PR DESCRIPTION
## Summary

The weekly leaderboard was showing incorrect rankings — kids who completed quests in the evening (after ~7pm CT) appeared with 0 weekly XP because their transactions were excluded from the week window.

## Root Cause

The leaderboard query in `backend/routers/stats.py` filtered transactions using:

```python
func.date(PointTransaction.created_at) >= monday,
func.date(PointTransaction.created_at) <= sunday,
```

SQLite's `date()` on a stored UTC timestamp returns the **UTC date**, not the local date. Transactions created after 7pm CT (midnight UTC) got a UTC date of the next day, placing them outside the `[monday, sunday]` window. Affected kids showed 0 weekly XP and ranked last regardless of how much they earned.

## Fix

Wrap `created_at` in `datetime(..., 'localtime')` before extracting the date, so SQLite converts the UTC timestamp to the server's local timezone (set via `TZ=America/Chicago`) before comparison:

```python
func.date(func.datetime(PointTransaction.created_at, 'localtime')) >= monday,
func.date(func.datetime(PointTransaction.created_at, 'localtime')) <= sunday,
```

## Test plan

- [ ] Kid completes quests in the evening — verify they appear correctly ranked on the leaderboard
- [ ] Leaderboard resets correctly at the start of a new week (Monday)

🤖 Generated with [Claude Code](https://claude.com/claude-code)