### PR TITLE
fix: correct UTC→local date conversions in progress, shoutouts, achievements, stats

### DIFF
--- a/backend/achievements.py
+++ b/backend/achievements.py
@@ -1,4 +1,7 @@
 from datetime import datetime, date, timezone
+from zoneinfo import ZoneInfo
+
+_LOCAL_TZ = ZoneInfo('America/Chicago')
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from backend.models import (
@@ -53,8 +56,10 @@ async def _check_criteria(db: AsyncSession, user: User, criteria: dict) -> bool:
             )
         )
         for assignment in result.scalars().all():
-            if assignment.completed_at and assignment.completed_at.hour < hour:
-                return True
+            if assignment.completed_at:
+                local_hour = assignment.completed_at.replace(tzinfo=timezone.utc).astimezone(_LOCAL_TZ).hour
+                if local_hour < hour:
+                    return True
         return False
 
     elif ctype == "streak_reached":
@@ -86,8 +91,10 @@ async def _check_criteria(db: AsyncSession, user: User, criteria: dict) -> bool:
         for a in assignments:
             if a.status == AssignmentStatus.pending:
                 return False
-            if a.completed_at and a.completed_at.hour >= hour:
-                return False
+            if a.completed_at:
+                local_hour = a.completed_at.replace(tzinfo=timezone.utc).astimezone(_LOCAL_TZ).hour
+                if local_hour >= hour:
+                    return False
         return True
 
     elif ctype == "all_daily_completed":

--- a/backend/routers/progress.py
+++ b/backend/routers/progress.py
@@ -40,16 +40,16 @@ async def get_progress(
     # Daily XP earned
     xp_result = await db.execute(
         select(
-            func.date(PointTransaction.created_at).label("day"),
+            func.date(func.datetime(PointTransaction.created_at, 'localtime')).label("day"),
             func.sum(PointTransaction.amount).label("xp"),
         )
         .where(
             PointTransaction.user_id.in_(user_ids),
             PointTransaction.amount > 0,
-            func.date(PointTransaction.created_at) >= start,
-            func.date(PointTransaction.created_at) <= today,
+            func.date(func.datetime(PointTransaction.created_at, 'localtime')) >= start,
+            func.date(func.datetime(PointTransaction.created_at, 'localtime')) <= today,
         )
-        .group_by(func.date(PointTransaction.created_at))
+        .group_by(func.date(func.datetime(PointTransaction.created_at, 'localtime')))
     )
     xp_by_day = {str(row.day): row.xp or 0 for row in xp_result.all()}
 

--- a/backend/routers/shoutouts.py
+++ b/backend/routers/shoutouts.py
@@ -1,7 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone, date
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.database import get_db
@@ -19,10 +19,10 @@ async def list_shoutouts(
     current_user: User = Depends(get_current_user),
 ):
     """Recent shoutouts (last 7 days)."""
-    cutoff = datetime.utcnow() - timedelta(days=7)
+    seven_days_ago = date.today() - timedelta(days=7)
     result = await db.execute(
         select(Shoutout)
-        .where(Shoutout.created_at >= cutoff)
+        .where(func.date(func.datetime(Shoutout.created_at, 'localtime')) >= str(seven_days_ago))
         .order_by(Shoutout.created_at.desc())
         .limit(50)
     )
@@ -73,12 +73,12 @@ async def create_shoutout(
     if not target:
         raise HTTPException(status_code=404, detail="User not found")
 
-    # Rate limit: max 5 shoutouts per user per day
-    today_start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    # Rate limit: max 5 shoutouts per user per local calendar day
+    today_local = date.today()
     count_result = await db.execute(
         select(Shoutout).where(
             Shoutout.from_user_id == current_user.id,
-            Shoutout.created_at >= today_start,
+            func.date(func.datetime(Shoutout.created_at, 'localtime')) == str(today_local),
         )
     )
     if len(count_result.scalars().all()) >= 5:

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import HTMLResponse
@@ -155,11 +155,11 @@ async def get_party(
     today_completed = await _count_today_assignments_by_kid(db, kid_ids, today, completed_only=True) if kid_ids else {}
 
     # Recent activity: last 48 hours of point transactions + avatar drops
-    two_days_ago = today - timedelta(days=2)
+    two_days_ago_dt = datetime.now(timezone.utc) - timedelta(days=2)
     activity_result = await db.execute(
         select(PointTransaction)
         .where(
-            PointTransaction.created_at >= str(two_days_ago),
+            PointTransaction.created_at >= two_days_ago_dt.replace(tzinfo=None),
             PointTransaction.amount > 0,
             PointTransaction.type.in_([PointType.chore_complete, PointType.achievement, PointType.event_multiplier]),
         )
@@ -173,7 +173,7 @@ async def get_party(
         select(Notification)
         .where(
             Notification.type == NotificationType.avatar_item_drop,
-            Notification.created_at >= str(two_days_ago),
+            Notification.created_at >= two_days_ago_dt.replace(tzinfo=None),
         )
         .order_by(Notification.created_at.desc())
         .limit(10)


### PR DESCRIPTION
## Summary

- **progress.py**: XP chart day boundaries now use local time — fixes chart attributing evening XP to the wrong day after ~7pm CT
- **shoutouts.py**: 7-day history window and per-day rate limit now compare against local calendar date instead of `datetime.utcnow()`
- **achievements.py**: Time-based achievement checks (`completion_before_time`, `all_daily_before_time`) now convert stored UTC timestamps to local TZ before checking the hour
- **stats.py**: Activity feed cutoff uses a proper UTC datetime object instead of a bare date string, preventing the comparison from silently matching nothing after midnight UTC

## Root cause

SQLite stores timestamps as naive UTC strings. `func.date(col)` extracts the UTC date, which diverges from local date after ~7pm CT. The fix wraps the column with `func.datetime(col, 'localtime')` in SQL, and uses `ZoneInfo('America/Chicago')` for Python-side hour checks.

## Test plan
- [ ] Merge and deploy; verify progress chart shows today's XP on the correct day in the evening
- [ ] Send a shoutout after 7pm CT; confirm it appears in today's history and counts against today's rate limit
- [ ] Complete a chore before 8am CT; confirm early-bird achievement triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)