### PR TITLE
fix: add bounty board toggle to chore cards

### DIFF
--- a/frontend/src/pages/Chores.jsx
+++ b/frontend/src/pages/Chores.jsx
@@ -410,6 +410,22 @@ export default function Chores() {
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
+                          api(`/api/chores/${chore.id}`, {
+                            method: 'PUT',
+                            body: { is_bounty: !chore.is_bounty },
+                          }).then(() => fetchChores()).catch(() => {});
+                        }}
+                        className={`p-1 rounded-md hover:bg-surface-raised transition-colors ${
+                          chore.is_bounty ? 'text-accent' : 'text-muted hover:text-accent'
+                        }`}
+                        aria-label={chore.is_bounty ? 'Remove from Bounty Board' : 'Add to Bounty Board'}
+                        title={chore.is_bounty ? 'On Bounty Board — click to remove' : 'Add to Bounty Board'}
+                      >
+                        <ScrollText size={13} />
+                      </button>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
                           setEditingChore(chore);
                           setShowCreateModal(true);
                         }}


### PR DESCRIPTION
## Summary

The bounty board toggle was added to `ChoreDetail.jsx` but was unreachable for unassigned chores — clicking an unassigned chore card opened the assign modal instead of navigating to the detail page.

## Fix

Added a `ScrollText` icon button directly on each chore card in the quest library (next to the existing pencil/trash buttons):
- **Grey** = not on the bounty board
- **Accent colour (lit up)** = currently on the bounty board
- One click toggles `is_bounty` on/off without entering the detail page

This commit was pushed to the `feat/bounty-board` branch after PR #27 was already merged, so it was never included in main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)