### PR TITLE
Fix Bounty Board card icons rendering as raw text

### DIFF
--- a/frontend/src/pages/BountyBoard.jsx
+++ b/frontend/src/pages/BountyBoard.jsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { api } from '../api/client';
 import { useAuth } from '../hooks/useAuth';
+import ChoreIcon from '../components/ChoreIcon';
 
 const DIFFICULTY_COLORS = {
   easy: 'text-green-400',
@@ -285,10 +286,10 @@ function BountyCard({ bounty, isParent, actionLoading, onClaim, onComplete, onAb
     <div className="game-panel p-4 transition-all" style={{ borderLeftColor: catColor, borderLeftWidth: 3 }}>
       <div className="flex items-start gap-3">
         <div
-          className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 text-lg"
+          className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0"
           style={{ backgroundColor: `${catColor}20` }}
         >
-          {bounty.icon || '📜'}
+          <ChoreIcon name={bounty.icon} size={18} className="text-cream/70" />
         </div>
 
         <div className="flex-1 min-w-0">
@@ -420,8 +421,8 @@ function ClaimReviewCard({ claim, bounties, actionLoading, onVerify, onReject })
   return (
     <div className="game-panel p-4">
       <div className="flex items-start gap-3">
-        <div className="w-9 h-9 rounded-lg bg-accent/20 flex items-center justify-center flex-shrink-0 text-lg">
-          {bounty?.icon || '📜'}
+        <div className="w-9 h-9 rounded-lg bg-accent/20 flex items-center justify-center flex-shrink-0">
+          <ChoreIcon name={bounty?.icon} size={18} className="text-accent opacity-80" />
         </div>
         <div className="flex-1 min-w-0">
           <p className="text-cream text-sm font-semibold truncate">


### PR DESCRIPTION
## Summary
- Bounty Board cards were displaying raw Lucide icon name strings (e.g. "cooking-pot", "flower-2") as text inside the icon box, causing overflow and layout breakage
- Fix: import and use the existing `ChoreIcon` component, which converts kebab-case names to proper Lucide React components
- Applies to both `BountyCard` and `ClaimReviewCard` components

## Test plan
- [ ] Browse Bounty Board — cards show proper icons, no text overflow
- [ ] Review Claims tab — claim cards show proper icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)