### PR TITLE
Add in-app update check and one-click deploy trigger

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -165,7 +165,7 @@ async def security_headers(request: Request, call_next):
 from backend.routers import (  # noqa: E402
     auth, chores, rewards, points, stats, calendar,
     notifications, admin, avatar, wishlist, events, spin, rotations, uploads, push,
-    shoutouts, vacation, progress, emotes, announcements, pets, bounty,
+    shoutouts, vacation, progress, emotes, announcements, pets, bounty, update,
 )
 
 app.include_router(auth.router)
@@ -190,6 +190,7 @@ app.include_router(emotes.router)
 app.include_router(announcements.router)
 app.include_router(pets.router)
 app.include_router(bounty.router)
+app.include_router(update.router)
 
 
 @app.get("/api/health")

--- a/backend/routers/update.py
+++ b/backend/routers/update.py
@@ -1,0 +1,107 @@
+"""
+In-app update management.
+
+GET  /api/admin/update/check   — compare current build vs latest GitHub commit
+POST /api/admin/update/trigger — write a flag file that the host watchdog picks up
+
+Architecture note: the container cannot rebuild itself (the frontend is baked in at
+image-build time). Triggering an update writes /app/data/.update_requested; the
+host-side watchdog.sh detects that file and runs deploy.sh outside the container.
+"""
+
+import asyncio
+import json
+import os
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.dependencies import require_admin, require_parent
+from backend.models import User
+
+router = APIRouter(prefix="/api/admin/update", tags=["update"])
+
+GITHUB_REPO = os.environ.get("GITHUB_REPO", "turbogizzmo/ChoreQuest")
+FLAG_FILE = Path("/app/data/.update_requested")
+
+
+def _fetch_latest_commit() -> dict:
+    """Synchronous GitHub API call — run via asyncio.to_thread."""
+    url = f"https://api.github.com/repos/{GITHUB_REPO}/commits/main"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github.v3+json",
+            "User-Agent": "ChoreQuest-UpdateCheck/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"GitHub API error {e.code}: {e.reason}")
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"Network error: {e.reason}")
+
+
+@router.get("/check")
+async def check_for_updates(_: User = Depends(require_parent)):
+    """
+    Compare the running GIT_COMMIT env var against the latest commit on main.
+    Accessible to parents and admins (read-only check).
+    """
+    current = os.environ.get("GIT_COMMIT", "unknown")
+
+    if current == "unknown":
+        return {
+            "current": "unknown",
+            "latest": None,
+            "update_available": False,
+            "message": "Version tracking not available (dev/local build)",
+        }
+
+    try:
+        data = await asyncio.to_thread(_fetch_latest_commit)
+    except RuntimeError as e:
+        raise HTTPException(502, detail=str(e))
+
+    latest_sha = data["sha"]
+    latest_short = latest_sha[:7]
+    commit_info = data.get("commit", {})
+    commit_msg = commit_info.get("message", "").split("\n")[0]
+    commit_date = commit_info.get("committer", {}).get("date") or commit_info.get("author", {}).get("date")
+    author = commit_info.get("author", {}).get("name", "unknown")
+
+    # Current GIT_COMMIT is the short hash (7 chars); latest is the full 40-char SHA.
+    update_available = not latest_sha.startswith(current)
+
+    return {
+        "current": current,
+        "latest": latest_short,
+        "latest_full": latest_sha,
+        "update_available": update_available,
+        "commit_message": commit_msg,
+        "commit_date": commit_date,
+        "commit_author": author,
+    }
+
+
+@router.post("/trigger")
+async def trigger_update(admin: User = Depends(require_admin)):
+    """
+    Request an update by writing a flag file to the data volume.
+    The host-side watchdog.sh picks this up and runs deploy.sh.
+    Admin-only.
+    """
+    try:
+        FLAG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        FLAG_FILE.touch(exist_ok=True)
+    except OSError as e:
+        raise HTTPException(500, detail=f"Could not write update flag: {e}")
+
+    return {
+        "status": "ok",
+        "message": "Update requested. The watchdog will pull and restart the container shortly.",
+    }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "8122:8122"
     environment:
       - SECRET_KEY=${SECRET_KEY}
-      - TZ=America/Chicago
+      - TZ=${TZ:-America/Chicago}
     volumes:
       - ./data:/app/data
     restart: unless-stopped

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -10,11 +10,22 @@ import {
   Award,
   ArrowLeft,
   GitCommit,
+  RefreshCw,
+  ArrowUpCircle,
+  CheckCircle2,
+  AlertTriangle,
+  Wifi,
 } from 'lucide-react';
 import VacationSettings from '../components/VacationSettings';
 
-function VersionInfo() {
+function UpdatePanel({ isAdmin }) {
   const [version, setVersion] = useState(null);
+  const [checking, setChecking] = useState(false);
+  const [updateInfo, setUpdateInfo] = useState(null); // null = not checked yet
+  const [triggering, setTriggering] = useState(false);
+  const [triggerMsg, setTriggerMsg] = useState('');
+
+  // Load current version from health endpoint on mount
   useEffect(() => {
     fetch('/api/health')
       .then((r) => r.json())
@@ -22,18 +33,150 @@ function VersionInfo() {
       .catch(() => {});
   }, []);
 
-  if (!version) return null;
+  const checkForUpdates = async () => {
+    setChecking(true);
+    setUpdateInfo(null);
+    setTriggerMsg('');
+    try {
+      const res = await fetch('/api/admin/update/check', {
+        headers: { Authorization: `Bearer ${localStorage.getItem('access_token')}` },
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.detail || 'Check failed');
+      setUpdateInfo(data);
+    } catch (err) {
+      setUpdateInfo({ error: err.message });
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const applyUpdate = async () => {
+    setTriggering(true);
+    setTriggerMsg('');
+    try {
+      const res = await fetch('/api/admin/update/trigger', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${localStorage.getItem('access_token')}` },
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.detail || 'Trigger failed');
+      setTriggerMsg('Update scheduled! The app will restart in ~1-2 minutes.');
+    } catch (err) {
+      setTriggerMsg(`Error: ${err.message}`);
+    } finally {
+      setTriggering(false);
+    }
+  };
+
   return (
-    <div className="game-panel p-4 flex items-center justify-between">
-      <div className="flex items-center gap-2 text-muted">
-        <GitCommit size={14} />
-        <span className="text-xs">Version</span>
+    <div className="game-panel p-4 space-y-3">
+      {/* Header row */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-muted">
+          <GitCommit size={14} />
+          <span className="text-xs font-medium text-cream">Version</span>
+        </div>
+        {version?.version && version.version !== 'unknown' && (
+          <p className="text-cream text-xs font-mono">{version.version}</p>
+        )}
+        {(!version?.version || version.version === 'unknown') && (
+          <p className="text-muted text-xs font-mono">dev build</p>
+        )}
       </div>
-      <div className="text-right">
-        <p className="text-cream text-xs font-mono">{version.version}</p>
-        {version.build_date && version.build_date !== 'unknown' && (
-          <p className="text-muted text-[11px]">
-            {new Date(version.build_date).toLocaleString()}
+
+      {version?.build_date && version.build_date !== 'unknown' && (
+        <p className="text-muted text-[11px]">
+          Built {new Date(version.build_date).toLocaleString()}
+        </p>
+      )}
+
+      {/* Update check — parents and admins can check; only admins can apply */}
+      <div className="pt-1 border-t border-border/50 space-y-2">
+        <button
+          onClick={checkForUpdates}
+          disabled={checking}
+          className="game-btn game-btn-blue !py-1.5 !px-3 !text-xs flex items-center gap-1.5"
+        >
+          {checking
+            ? <Loader2 size={12} className="animate-spin" />
+            : <RefreshCw size={12} />}
+          {checking ? 'Checking…' : 'Check for Updates'}
+        </button>
+
+        {/* Result */}
+        {updateInfo && !updateInfo.error && (
+          <div className={`rounded-md p-3 border text-xs space-y-1.5 ${
+            updateInfo.update_available
+              ? 'bg-accent/10 border-accent/30'
+              : 'bg-emerald/10 border-emerald/30'
+          }`}>
+            {updateInfo.update_available ? (
+              <>
+                <div className="flex items-center gap-1.5 text-accent font-semibold">
+                  <ArrowUpCircle size={13} />
+                  Update available ({updateInfo.latest})
+                </div>
+                {updateInfo.commit_message && (
+                  <p className="text-cream/80 line-clamp-2">{updateInfo.commit_message}</p>
+                )}
+                {updateInfo.commit_date && (
+                  <p className="text-muted">
+                    {new Date(updateInfo.commit_date).toLocaleString()} · {updateInfo.commit_author}
+                  </p>
+                )}
+                {isAdmin && !triggerMsg && (
+                  <button
+                    onClick={applyUpdate}
+                    disabled={triggering}
+                    className="game-btn game-btn-blue !py-1.5 !px-3 !text-xs flex items-center gap-1.5 mt-2"
+                  >
+                    {triggering
+                      ? <Loader2 size={12} className="animate-spin" />
+                      : <ArrowUpCircle size={12} />}
+                    {triggering ? 'Scheduling…' : 'Apply Update'}
+                  </button>
+                )}
+                {!isAdmin && (
+                  <p className="text-muted italic">Ask an admin to apply the update.</p>
+                )}
+              </>
+            ) : (
+              <div className="flex items-center gap-1.5 text-emerald font-medium">
+                <CheckCircle2 size={13} />
+                Up to date ({updateInfo.current})
+              </div>
+            )}
+          </div>
+        )}
+
+        {updateInfo?.message && !updateInfo.update_available && !updateInfo.error && (
+          <p className="text-muted text-xs italic">{updateInfo.message}</p>
+        )}
+
+        {updateInfo?.error && (
+          <div className="flex items-center gap-1.5 text-crimson text-xs">
+            <Wifi size={12} />
+            {updateInfo.error}
+          </div>
+        )}
+
+        {triggerMsg && (
+          <div className={`flex items-start gap-1.5 text-xs p-2 rounded-md border ${
+            triggerMsg.startsWith('Error')
+              ? 'text-crimson border-crimson/30 bg-crimson/10'
+              : 'text-accent border-accent/30 bg-accent/10'
+          }`}>
+            {triggerMsg.startsWith('Error')
+              ? <AlertTriangle size={12} className="flex-shrink-0 mt-0.5" />
+              : <CheckCircle2 size={12} className="flex-shrink-0 mt-0.5" />}
+            {triggerMsg}
+          </div>
+        )}
+
+        {isAdmin && (
+          <p className="text-muted text-[11px] leading-relaxed">
+            Requires <span className="font-mono text-cream/60">watchdog.sh</span> running on the host. See the repo for setup.
           </p>
         )}
       </div>
@@ -397,7 +540,7 @@ export default function Settings() {
             </div>
           )}
 
-          <VersionInfo />
+          <UpdatePanel isAdmin={user?.role === 'admin'} />
         </div>
       )}
     </div>

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# watchdog.sh — monitors for in-app update requests and runs deploy.sh
+#
+# Run this once on the host (outside Docker):
+#   nohup bash /path/to/ChoreQuest/watchdog.sh >> /path/to/ChoreQuest/data/watchdog.log 2>&1 &
+#
+# Or set it up as a cron job (checks every minute):
+#   * * * * * /bin/bash /path/to/ChoreQuest/watchdog.sh --cron >> /path/to/ChoreQuest/data/watchdog.log 2>&1
+#
+# How it works:
+#   1. The ChoreQuest app writes /app/data/.update_requested when an admin
+#      clicks "Apply Update" in Settings.
+#   2. This script detects that file (it's in the ./data/ folder on the host),
+#      removes it, and runs deploy.sh to git pull + rebuild + restart.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FLAG_FILE="$SCRIPT_DIR/data/.update_requested"
+LOCK_FILE="$SCRIPT_DIR/data/.update_in_progress"
+DEPLOY_SCRIPT="$SCRIPT_DIR/deploy.sh"
+CRON_MODE=false
+
+[[ "${1:-}" == "--cron" ]] && CRON_MODE=true
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+deploy() {
+  if [ -f "$LOCK_FILE" ]; then
+    log "Deploy already in progress, skipping."
+    return
+  fi
+
+  log "Update flag detected. Starting deploy..."
+  touch "$LOCK_FILE"
+  rm -f "$FLAG_FILE"
+
+  if bash "$DEPLOY_SCRIPT"; then
+    log "Deploy completed successfully."
+  else
+    log "ERROR: Deploy script exited with an error."
+  fi
+
+  rm -f "$LOCK_FILE"
+}
+
+if $CRON_MODE; then
+  # Single-shot mode for cron: check once and exit
+  if [ -f "$FLAG_FILE" ]; then
+    deploy
+  fi
+  exit 0
+fi
+
+# Daemon mode: loop until killed
+log "ChoreQuest watchdog started (PID $$). Monitoring: $FLAG_FILE"
+log "Press Ctrl+C to stop."
+
+while true; do
+  if [ -f "$FLAG_FILE" ]; then
+    deploy
+  fi
+  sleep 30
+done


### PR DESCRIPTION
## Summary
- **Update check**: Settings page now has a "Check for Updates" button that hits the GitHub API and shows if a newer commit exists on main, including the commit message and author
- **Apply Update**: Admin-only button writes a flag file to `/app/data/.update_requested` which the host watchdog picks up
- **watchdog.sh**: New host-side script — run once on the NAS, polls every 30s for the flag and calls `deploy.sh`. Also supports `--cron` mode for cron-based polling
- **TZ fix**: `docker-compose.yml` now uses `${TZ:-America/Chicago}` so timezone is configurable via `.env` without causing git conflicts on pull

## NAS setup (one-time)
```bash
# From the ChoreQuest folder on the NAS:
nohup bash watchdog.sh >> data/watchdog.log 2>&1 &
```
Or add to cron for reboot persistence:
```
* * * * * bash /volume1/docker/chorequest/watchdog.sh --cron >> /volume1/docker/chorequest/data/watchdog.log 2>&1
```

## Test plan
- [ ] Settings → Version panel shows current commit hash
- [ ] "Check for Updates" returns up-to-date or shows new commit info
- [ ] "Apply Update" button visible for admin, hidden for parents
- [ ] Trigger endpoint writes flag file to `./data/.update_requested`
- [ ] watchdog.sh detects flag, deletes it, runs deploy.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)