### PR TITLE
feat: floating toast notification system

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import { useAuth } from './hooks/useAuth';
 import { useWebSocket } from './hooks/useWebSocket';
 import Layout from './components/Layout';
 import UpdatePrompt from './components/UpdatePrompt';
+import { ToastProvider } from './components/Toast';
 
 const Login = lazy(() => import('./pages/Login'));
 const Register = lazy(() => import('./pages/Register'));
@@ -46,14 +47,16 @@ export default function App() {
 
   if (!user) {
     return (
-      <Suspense fallback={<Loading />}>
-        <UpdatePrompt />
-        <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route path="/register" element={<Register />} />
-          <Route path="*" element={<Navigate to="/login" replace />} />
-        </Routes>
-      </Suspense>
+      <ToastProvider>
+        <Suspense fallback={<Loading />}>
+          <UpdatePrompt />
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route path="/register" element={<Register />} />
+            <Route path="*" element={<Navigate to="/login" replace />} />
+          </Routes>
+        </Suspense>
+      </ToastProvider>
     );
   }
 
@@ -62,29 +65,31 @@ export default function App() {
     : ParentDashboard;
 
   return (
-    <Layout>
-      <UpdatePrompt />
-      <Suspense fallback={<Loading />}>
-        <Routes>
-          <Route path="/" element={<DashboardComponent />} />
-          <Route path="/chores" element={<Chores />} />
-          <Route path="/chores/:id" element={<ChoreDetail />} />
-          <Route path="/rewards" element={<Rewards />} />
-          <Route path="/inventory" element={<Navigate to="/rewards?tab=inventory" replace />} />
-          <Route path="/wishlist" element={<Navigate to="/rewards?tab=wishlist" replace />} />
-          <Route path="/calendar" element={<Calendar />} />
-          <Route path="/party" element={<Party />} />
-          <Route path="/leaderboard" element={<Leaderboard />} />
-          <Route path="/profile" element={<Profile />} />
-          <Route path="/avatar" element={<AvatarEditor />} />
-          <Route path="/events" element={<Events />} />
-          <Route path="/kids/:kidId" element={<KidQuests />} />
-          <Route path="/bounty" element={<BountyBoard />} />
-          <Route path="/settings" element={<Settings />} />
-          {user.role === 'admin' && <Route path="/admin" element={<AdminDashboard />} />}
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-      </Suspense>
-    </Layout>
+    <ToastProvider>
+      <Layout>
+        <UpdatePrompt />
+        <Suspense fallback={<Loading />}>
+          <Routes>
+            <Route path="/" element={<DashboardComponent />} />
+            <Route path="/chores" element={<Chores />} />
+            <Route path="/chores/:id" element={<ChoreDetail />} />
+            <Route path="/rewards" element={<Rewards />} />
+            <Route path="/inventory" element={<Navigate to="/rewards?tab=inventory" replace />} />
+            <Route path="/wishlist" element={<Navigate to="/rewards?tab=wishlist" replace />} />
+            <Route path="/calendar" element={<Calendar />} />
+            <Route path="/party" element={<Party />} />
+            <Route path="/leaderboard" element={<Leaderboard />} />
+            <Route path="/profile" element={<Profile />} />
+            <Route path="/avatar" element={<AvatarEditor />} />
+            <Route path="/events" element={<Events />} />
+            <Route path="/kids/:kidId" element={<KidQuests />} />
+            <Route path="/bounty" element={<BountyBoard />} />
+            <Route path="/settings" element={<Settings />} />
+            {user.role === 'admin' && <Route path="/admin" element={<AdminDashboard />} />}
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </Suspense>
+      </Layout>
+    </ToastProvider>
   );
 }

--- a/frontend/src/components/Toast.jsx
+++ b/frontend/src/components/Toast.jsx
@@ -1,0 +1,102 @@
+/**
+ * Floating toast notification system.
+ *
+ * Usage:
+ *   const { showToast } = useToast();
+ *   showToast('Quest completed!', 'success');
+ *   showToast('Something went wrong.', 'error');
+ *   showToast('Checking for updates…', 'info');
+ */
+
+import { createContext, useCallback, useContext, useState } from 'react';
+import { CheckCircle2, XCircle, Info, X } from 'lucide-react';
+
+// ─── Context ─────────────────────────────────────────────────────────────────
+
+const ToastContext = createContext(null);
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used inside <ToastProvider>');
+  return ctx;
+}
+
+// ─── Provider ────────────────────────────────────────────────────────────────
+
+let _nextId = 1;
+
+export function ToastProvider({ children }) {
+  const [toasts, setToasts] = useState([]);
+
+  const dismiss = useCallback((id) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const showToast = useCallback((message, type = 'info', duration = 4000) => {
+    const id = _nextId++;
+    setToasts((prev) => {
+      // Keep at most 3 toasts visible
+      const next = [...prev.slice(-2), { id, message, type }];
+      return next;
+    });
+    setTimeout(() => dismiss(id), duration);
+  }, [dismiss]);
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <ToastStack toasts={toasts} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  );
+}
+
+// ─── Toast stack UI ──────────────────────────────────────────────────────────
+
+const STYLES = {
+  success: {
+    bar: 'bg-surface border border-emerald/40',
+    icon: <CheckCircle2 size={16} className="text-emerald flex-shrink-0" />,
+    text: 'text-cream',
+  },
+  error: {
+    bar: 'bg-surface border border-crimson/40',
+    icon: <XCircle size={16} className="text-crimson flex-shrink-0" />,
+    text: 'text-cream',
+  },
+  info: {
+    bar: 'bg-surface border border-accent/40',
+    icon: <Info size={16} className="text-accent flex-shrink-0" />,
+    text: 'text-cream',
+  },
+};
+
+function ToastStack({ toasts, onDismiss }) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      className="fixed bottom-20 left-1/2 -translate-x-1/2 z-[9999] flex flex-col gap-2 items-center w-[min(92vw,420px)] pointer-events-none"
+      aria-live="polite"
+    >
+      {toasts.map((toast) => {
+        const s = STYLES[toast.type] || STYLES.info;
+        return (
+          <div
+            key={toast.id}
+            className={`${s.bar} rounded-xl px-4 py-3 flex items-center gap-3 shadow-lg pointer-events-auto w-full animate-in fade-in slide-in-from-bottom-2 duration-200`}
+          >
+            {s.icon}
+            <p className={`${s.text} text-sm flex-1 leading-snug`}>{toast.message}</p>
+            <button
+              onClick={() => onDismiss(toast.id)}
+              className="text-muted hover:text-cream transition-colors flex-shrink-0 -mr-1"
+              aria-label="Dismiss"
+            >
+              <X size={14} />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/pages/BountyBoard.jsx
+++ b/frontend/src/pages/BountyBoard.jsx
@@ -15,6 +15,7 @@ import {
 import { api } from '../api/client';
 import { useAuth } from '../hooks/useAuth';
 import ChoreIcon from '../components/ChoreIcon';
+import { useToast } from '../components/Toast';
 
 const DIFFICULTY_COLORS = {
   easy: 'text-green-400',
@@ -40,17 +41,18 @@ const STATUS_CONFIG = {
 export default function BountyBoard() {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const isParent = user?.role === 'parent' || user?.role === 'admin';
 
   const [bounties, setBounties] = useState([]);
   const [pendingClaims, setPendingClaims] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
+  const [loadError, setLoadError] = useState('');
   const [actionLoading, setActionLoading] = useState('');
   const [tab, setTab] = useState('board'); // 'board' | 'review'
 
   const fetchData = useCallback(async () => {
-    setError('');
+    setLoadError('');
     try {
       const data = await api('/api/bounty');
       setBounties(Array.isArray(data) ? data : []);
@@ -59,7 +61,7 @@ export default function BountyBoard() {
         setPendingClaims(Array.isArray(claims) ? claims : []);
       }
     } catch (err) {
-      setError(err.message || 'Could not load the Bounty Board');
+      setLoadError(err.message || 'Could not load the Bounty Board');
     } finally {
       setLoading(false);
     }
@@ -83,9 +85,10 @@ export default function BountyBoard() {
     setActionLoading(`claim-${choreId}`);
     try {
       await api(`/api/bounty/${choreId}/claim`, { method: 'POST' });
+      showToast('Bounty accepted! Get to work!', 'success');
       await fetchData();
     } catch (err) {
-      setError(err.message || 'Could not accept bounty');
+      showToast(err.message || 'Could not accept bounty', 'error');
     } finally {
       setActionLoading('');
     }
@@ -96,9 +99,10 @@ export default function BountyBoard() {
     try {
       const fd = new FormData();
       await api(`/api/bounty/${choreId}/complete`, { method: 'POST', body: fd });
+      showToast('Bounty turned in! Awaiting parent approval.', 'success');
       await fetchData();
     } catch (err) {
-      setError(err.message || 'Could not mark bounty complete');
+      showToast(err.message || 'Could not mark bounty complete', 'error');
     } finally {
       setActionLoading('');
     }
@@ -108,9 +112,10 @@ export default function BountyBoard() {
     setActionLoading(`abandon-${choreId}`);
     try {
       await api(`/api/bounty/${choreId}/claim`, { method: 'DELETE' });
+      showToast('Bounty abandoned.', 'info');
       await fetchData();
     } catch (err) {
-      setError(err.message || 'Could not abandon bounty');
+      showToast(err.message || 'Could not abandon bounty', 'error');
     } finally {
       setActionLoading('');
     }
@@ -120,9 +125,10 @@ export default function BountyBoard() {
     setActionLoading(`verify-${claimId}`);
     try {
       await api(`/api/bounty/claims/${claimId}/verify`, { method: 'POST' });
+      showToast('Bounty approved! XP awarded.', 'success');
       await fetchData();
     } catch (err) {
-      setError(err.message || 'Could not approve claim');
+      showToast(err.message || 'Could not approve claim', 'error');
     } finally {
       setActionLoading('');
     }
@@ -132,9 +138,10 @@ export default function BountyBoard() {
     setActionLoading(`reject-${claimId}`);
     try {
       await api(`/api/bounty/claims/${claimId}/reject`, { method: 'POST' });
+      showToast('Claim sent back for revision.', 'info');
       await fetchData();
     } catch (err) {
-      setError(err.message || 'Could not reject claim');
+      showToast(err.message || 'Could not reject claim', 'error');
     } finally {
       setActionLoading('');
     }
@@ -168,10 +175,10 @@ export default function BountyBoard() {
         </div>
       </div>
 
-      {error && (
+      {loadError && (
         <div className="game-panel p-3 flex items-center gap-2 border-crimson/30 text-crimson text-sm">
           <AlertCircle size={16} className="flex-shrink-0" />
-          {error}
+          {loadError}
         </div>
       )}
 

--- a/frontend/src/pages/ChoreDetail.jsx
+++ b/frontend/src/pages/ChoreDetail.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { api } from '../api/client';
 import { useAuth } from '../hooks/useAuth';
+import { useToast } from '../components/Toast';
 import { useTheme } from '../hooks/useTheme';
 import { todayLocalISO } from '../utils/dates';
 import { themedTitle, themedDescription } from '../utils/questThemeText';
@@ -88,6 +89,7 @@ export default function ChoreDetail() {
   const { user } = useAuth();
   const { colorTheme } = useTheme();
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const isParent = user?.role === 'parent' || user?.role === 'admin';
   const isKid = user?.role === 'kid';
 
@@ -95,7 +97,6 @@ export default function ChoreDetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [actionLoading, setActionLoading] = useState('');
-  const [actionMessage, setActionMessage] = useState('');
 
   // Rotation state (parent only)
   const [rotation, setRotation] = useState(null);
@@ -150,13 +151,12 @@ export default function ChoreDetail() {
 
   const handleComplete = async () => {
     setActionLoading('complete');
-    setActionMessage('');
     try {
       await api(`/api/chores/${id}/complete`, { method: 'POST' });
-      setActionMessage('Quest completed! XP has been awarded to your hero.');
+      showToast('Quest completed! XP awarded! 🎉', 'success');
       await fetchChore();
     } catch (err) {
-      setActionMessage(err.message || 'Failed to complete the quest.');
+      showToast(err.message || 'Failed to complete the quest.', 'error');
     } finally {
       setActionLoading('');
     }
@@ -164,16 +164,15 @@ export default function ChoreDetail() {
 
   const handleVerify = async (assignmentId) => {
     setActionLoading('verify');
-    setActionMessage('');
     try {
       const path = assignmentId
         ? `/api/chores/assignments/${assignmentId}/verify`
         : `/api/chores/${id}/verify`;
       await api(path, { method: 'POST' });
-      setActionMessage('Quest verified! The hero has been rewarded.');
+      showToast('Quest verified! The hero has been rewarded.', 'success');
       await fetchChore();
     } catch (err) {
-      setActionMessage(err.message || 'Verification failed.');
+      showToast(err.message || 'Verification failed.', 'error');
     } finally {
       setActionLoading('');
     }
@@ -181,16 +180,15 @@ export default function ChoreDetail() {
 
   const handleUncomplete = async (assignmentId) => {
     setActionLoading('uncomplete');
-    setActionMessage('');
     try {
       const path = assignmentId
         ? `/api/chores/assignments/${assignmentId}/uncomplete`
         : `/api/chores/${id}/uncomplete`;
       await api(path, { method: 'POST' });
-      setActionMessage('Quest marked as incomplete.');
+      showToast('Quest marked as incomplete.', 'info');
       await fetchChore();
     } catch (err) {
-      setActionMessage(err.message || 'Could not undo completion.');
+      showToast(err.message || 'Could not undo completion.', 'error');
     } finally {
       setActionLoading('');
     }
@@ -198,23 +196,22 @@ export default function ChoreDetail() {
 
   const handleSkip = async (assignmentId) => {
     setActionLoading('skip');
-    setActionMessage('');
     try {
       const path = assignmentId
         ? `/api/chores/assignments/${assignmentId}/skip`
         : `/api/chores/${id}/skip`;
       await api(path, { method: 'POST' });
-      setActionMessage('Quest skipped for today.');
+      showToast('Quest skipped for today.', 'info');
       await fetchChore();
     } catch (err) {
-      setActionMessage(err.message || 'Could not skip the quest.');
+      showToast(err.message || 'Could not skip the quest.', 'error');
     } finally {
       setActionLoading('');
     }
   };
 
   const handleCreateRotation = async () => {
-    if (allKids.length < 2) { setActionMessage('Need at least 2 kids for a rotation.'); return; }
+    if (allKids.length < 2) { showToast('Need at least 2 kids for a rotation.', 'info'); return; }
     setActionLoading('rotation');
     try {
       await api('/api/rotations', {
@@ -222,9 +219,9 @@ export default function ChoreDetail() {
         body: { chore_id: parseInt(id), kid_ids: allKids.map((k) => k.id), cadence: selectedCadence },
       });
       await fetchRotation();
-      setActionMessage('Rotation created.');
+      showToast('Rotation created.', 'success');
     } catch (err) {
-      setActionMessage(err.message || 'Could not create rotation.');
+      showToast(err.message || 'Could not create rotation.', 'error');
     } finally {
       setActionLoading('');
     }
@@ -236,9 +233,9 @@ export default function ChoreDetail() {
     try {
       await api(`/api/rotations/${rotation.id}/advance`, { method: 'POST' });
       await fetchRotation();
-      setActionMessage('Rotation advanced to next kid.');
+      showToast('Rotation advanced to next kid.', 'info');
     } catch (err) {
-      setActionMessage(err.message || 'Could not advance rotation.');
+      showToast(err.message || 'Could not advance rotation.', 'error');
     } finally {
       setActionLoading('');
     }
@@ -253,9 +250,9 @@ export default function ChoreDetail() {
         body: { cadence: newCadence },
       });
       await fetchRotation();
-      setActionMessage(`Cadence updated to ${newCadence}.`);
+      showToast(`Rotation cadence set to ${newCadence}.`, 'info');
     } catch (err) {
-      setActionMessage(err.message || 'Could not update cadence.');
+      showToast(err.message || 'Could not update cadence.', 'error');
     } finally {
       setActionLoading('');
     }
@@ -267,9 +264,9 @@ export default function ChoreDetail() {
     try {
       await api(`/api/rotations/${rotation.id}`, { method: 'DELETE' });
       setRotation(null);
-      setActionMessage('Rotation removed.');
+      showToast('Rotation removed.', 'info');
     } catch (err) {
-      setActionMessage(err.message || 'Could not delete rotation.');
+      showToast(err.message || 'Could not delete rotation.', 'error');
     } finally {
       setActionLoading('');
     }
@@ -453,19 +450,6 @@ export default function ChoreDetail() {
           </div>
         )}
       </div>
-
-      {/* Action Message */}
-      {actionMessage && (
-        <div
-          className={`p-3 rounded border text-sm text-center ${
-            actionMessage.toLowerCase().includes('fail') || actionMessage.toLowerCase().includes('could not')
-              ? 'border-crimson/40 bg-crimson/10 text-crimson'
-              : 'border-emerald/40 bg-emerald/10 text-emerald'
-          }`}
-        >
-          {actionMessage}
-        </div>
-      )}
 
       {/* Actions for kids */}
       {isKid && hasPendingToday && (

--- a/frontend/src/pages/Chores.jsx
+++ b/frontend/src/pages/Chores.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../api/client';
 import { useAuth } from '../hooks/useAuth';
+import { useToast } from '../components/Toast';
 import { toLocalISO } from '../utils/dates';
 import { useTheme } from '../hooks/useTheme';
 import { themedTitle, themedDescription } from '../utils/questThemeText';
@@ -100,6 +101,7 @@ export default function Chores() {
   const { user } = useAuth();
   const { colorTheme } = useTheme();
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const isParent = user?.role === 'parent' || user?.role === 'admin';
   const isKid = user?.role === 'kid';
 
@@ -202,9 +204,10 @@ export default function Chores() {
         await api(`/api/chores/${choreId}/complete`, { method: 'POST' });
       }
       setPhotoFiles((prev) => { const next = { ...prev }; delete next[choreId]; return next; });
+      showToast('Quest complete! XP awarded! 🎉', 'success');
       await fetchAll();
     } catch (err) {
-      setError(err.message || 'Failed to complete quest');
+      showToast(err.message || 'Failed to complete quest', 'error');
     } finally {
       setCompletingId(null);
     }
@@ -245,9 +248,10 @@ export default function Chores() {
     try {
       await api(`/api/chores/${deleteTarget.id}`, { method: 'DELETE' });
       setDeleteTarget(null);
+      showToast('Quest removed.', 'info');
       await fetchChores();
     } catch (err) {
-      setError(err.message || 'Failed to remove the quest.');
+      showToast(err.message || 'Failed to remove the quest.', 'error');
     } finally {
       setDeleting(false);
     }

--- a/frontend/src/pages/KidDashboard.jsx
+++ b/frontend/src/pages/KidDashboard.jsx
@@ -10,13 +10,13 @@ import {
   Skull,
   Camera,
   Loader2,
-  AlertTriangle,
   ChevronRight,
   Heart,
   HandHeart,
   Gamepad2,
   ShieldOff,
 } from 'lucide-react';
+import { useToast } from '../components/Toast';
 import { api } from '../api/client';
 import { useAuth } from '../hooks/useAuth';
 import { useSettings } from '../hooks/useSettings';
@@ -81,6 +81,7 @@ export default function KidDashboard() {
   const { spin_wheel_enabled, grace_period_days } = useSettings();
   const { colorTheme } = useTheme();
   const navigate = useNavigate();
+  const { showToast } = useToast();
 
   // data state
   const [assignments, setAssignments] = useState([]);
@@ -91,7 +92,6 @@ export default function KidDashboard() {
 
   // ui state
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
   const [showConfetti, setShowConfetti] = useState(false);
   const [showThemePicker, setShowThemePicker] = useState(false);
 
@@ -115,7 +115,6 @@ export default function KidDashboard() {
 
   const fetchData = useCallback(async () => {
     try {
-      setError(null);
       const monday = getMondayOfThisWeek();
       const today = todayISO();
 
@@ -189,11 +188,11 @@ export default function KidDashboard() {
 
       setSpinAvailability(spinRes);
     } catch (err) {
-      setError(err.message || 'Failed to load quest data');
+      showToast(err.message || 'Failed to load quest data', 'error');
     } finally {
       setLoading(false);
     }
-  }, [user?.id, spin_wheel_enabled, grace_period_days]);
+  }, [user?.id, spin_wheel_enabled, grace_period_days, showToast]);
 
   useEffect(() => {
     fetchData();
@@ -219,9 +218,10 @@ export default function KidDashboard() {
     try {
       await api(`/api/chores/${assignment.chore_id}/complete`, { method: 'POST' });
       setShowConfetti(true);
+      showToast('Quest complete! XP awarded! 🎉', 'success');
       await fetchData();
     } catch (err) {
-      setError(err.message || 'Could not complete quest');
+      showToast(err.message || 'Could not complete quest', 'error');
       await fetchData();
     } finally {
       setCompletingOverdue(null);
@@ -238,9 +238,10 @@ export default function KidDashboard() {
     try {
       await api(`/api/chores/${assignment.chore_id}/complete`, { method: 'POST' });
       setShowConfetti(true);
+      showToast('Quest complete! XP awarded! 🎉', 'success');
       await fetchData();
     } catch (err) {
-      setError(err.message || 'Could not complete quest');
+      showToast(err.message || 'Could not complete quest', 'error');
     } finally {
       setCompletingToday(null);
     }
@@ -375,13 +376,6 @@ export default function KidDashboard() {
         </div>
       )}
 
-      {/* ── Error banner ── */}
-      {error && (
-        <div className="game-panel p-3 flex items-center gap-2 border-crimson/30 text-crimson text-sm">
-          <AlertTriangle size={16} />
-          <span>{error}</span>
-        </div>
-      )}
 
       {/* ── Overdue quests (grace period) ── */}
       {overdueAssignments.length > 0 && (


### PR DESCRIPTION
## Summary

- Adds a new `Toast.jsx` component with `ToastProvider`, `useToast()` hook, and `ToastStack` UI
- Wraps the entire app in `ToastProvider` so every page can call `showToast()`
- Replaces silent inline error banners and static action message boxes with floating toasts across all key pages

## Pages updated

| Page | Before | After |
|------|--------|-------|
| `KidDashboard` | Red banner that could sit unseen above the fold | Toast on complete success ✅ / error ❌ |
| `Chores` | Inline error div below header | Toast on complete success / delete / error |
| `BountyBoard` | Single shared error div overwritten by each action | Toast per action (claim, turn in, abandon, approve, reject) |
| `ChoreDetail` | Static green/red action message panel mid-page | Toast for complete, verify, uncomplete, skip, all rotation actions |

## Toast behaviour

- Fixed position `bottom-20 center` — clears the mobile nav bar
- Three types: `success` (emerald), `error` (crimson), `info` (accent)
- Auto-dismisses after 4 s; X button for early dismiss
- Max 3 toasts visible at once (oldest drops off)
- `animate-in fade-in slide-in-from-bottom-2` entrance animation

## Test plan

- [ ] Complete a quest from KidDashboard home screen → green success toast appears
- [ ] Try completing an already-completed quest → red error toast with backend message
- [ ] Accept, turn in, and abandon a bounty → info/success toasts each step
- [ ] Parent approves/rejects a bounty claim → success/info toast
- [ ] Complete a quest from ChoreDetail → success toast (no inline banner)
- [ ] Parent skips / unverifies a quest → info toast
- [ ] Delete a quest in Chores → info toast
- [ ] Kill network and try to complete → red error toast with message

🤖 Generated with [Claude Code](https://claude.com/claude-code)