### PR TITLE
fix(rotation): calendar-week boundaries, configurable rotation day, first-kid skip

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -46,6 +46,8 @@ async def init_db():
             ("achievements", "sort_order", "INTEGER DEFAULT 0"),
             # Bounty Board
             ("chores", "is_bounty", "INTEGER DEFAULT 0"),
+            # Rotation day-of-week (0=Mon…6=Sun); default Monday
+            ("chore_rotations", "rotation_day", "INTEGER DEFAULT 0"),
         ]
         for table, col, typedef in _migrations:
             try:

--- a/backend/models.py
+++ b/backend/models.py
@@ -208,6 +208,9 @@ class ChoreRotation(Base):
     chore_id: Mapped[int] = mapped_column(ForeignKey("chores.id"), nullable=False)
     kid_ids: Mapped[list] = mapped_column(JSON, nullable=False)
     cadence: Mapped[RotationCadence] = mapped_column(Enum(RotationCadence), nullable=False)
+    # Day of week the rotation advances: 0=Monday … 6=Sunday (only meaningful for
+    # weekly / fortnightly cadences; ignored for daily and monthly).
+    rotation_day: Mapped[int] = mapped_column(Integer, default=0)
     current_index: Mapped[int] = mapped_column(Integer, default=0)
     last_rotated: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/backend/routers/rotations.py
+++ b/backend/routers/rotations.py
@@ -51,6 +51,7 @@ async def create_rotation(
         chore_id=body.chore_id,
         kid_ids=body.kid_ids,
         cadence=body.cadence,
+        rotation_day=body.rotation_day,
         current_index=0,
         last_rotated=datetime.now(timezone.utc),
     )
@@ -87,6 +88,12 @@ async def update_rotation(
 
     if body.cadence is not None:
         rotation.cadence = body.cadence
+
+    if body.rotation_day is not None:
+        rotation.rotation_day = body.rotation_day
+        # Reset last_rotated so the new boundary is measured from now,
+        # giving the current kid the full period from the new rotation_day.
+        rotation.last_rotated = datetime.now(timezone.utc)
 
     rotation.updated_at = datetime.now(timezone.utc)
     await db.commit()

--- a/backend/routers/rotations.py
+++ b/backend/routers/rotations.py
@@ -44,11 +44,15 @@ async def create_rotation(
     if existing is not None:
         raise HTTPException(status_code=409, detail="A rotation already exists for this chore")
 
+    # Set last_rotated to now so the first daily reset doesn't immediately
+    # advance past kid_ids[0]. Without this, should_advance_rotation() sees
+    # last_rotated=None → returns True → Kid A is skipped on the very first run.
     rotation = ChoreRotation(
         chore_id=body.chore_id,
         kid_ids=body.kid_ids,
         cadence=body.cadence,
         current_index=0,
+        last_rotated=datetime.now(timezone.utc),
     )
     db.add(rotation)
     await db.commit()

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -393,11 +393,14 @@ class RotationCreate(BaseModel):
     chore_id: int
     kid_ids: list[int]
     cadence: RotationCadence
+    # 0=Monday … 6=Sunday; used by weekly/fortnightly cadences
+    rotation_day: int = 0
 
 
 class RotationUpdate(BaseModel):
     kid_ids: list[int] | None = None
     cadence: RotationCadence | None = None
+    rotation_day: int | None = None
 
 
 class RotationResponse(BaseModel):
@@ -405,6 +408,7 @@ class RotationResponse(BaseModel):
     chore_id: int
     kid_ids: list[int]
     cadence: RotationCadence
+    rotation_day: int
     current_index: int
     last_rotated: datetime | None
     created_at: datetime

--- a/backend/services/rotation.py
+++ b/backend/services/rotation.py
@@ -5,30 +5,81 @@ from datetime import date, datetime, timedelta, timezone
 from backend.models import ChoreRotation, RotationCadence
 
 
+# ---------------------------------------------------------------------------
+# Calendar helpers
+# ---------------------------------------------------------------------------
+
+def week_start_for(d: date, rotation_day: int = 0) -> date:
+    """Return the most recent occurrence of *rotation_day* (0=Mon…6=Sun)
+    on or before *d*.
+
+    Examples
+    --------
+    rotation_day=0 (Monday) → behaves like the old monday_of_week()
+    rotation_day=6 (Sunday) → returns last Sunday on or before d
+    """
+    days_back = (d.weekday() - rotation_day) % 7
+    return d - timedelta(days=days_back)
+
+
+# Keep the old name as a convenience alias (used in tests / other services).
+def monday_of_week(d: date) -> date:
+    return week_start_for(d, rotation_day=0)
+
+
+def _boundaries_between(a: date, b: date, rotation_day: int = 0) -> int:
+    """Number of rotation-day boundaries from *a* (exclusive) to *b* (inclusive).
+
+    Positive when b > a, negative when b < a.  Two dates in the same
+    "rotation week" return 0.
+    """
+    return (week_start_for(b, rotation_day) - week_start_for(a, rotation_day)).days // 7
+
+
+# ---------------------------------------------------------------------------
+# Core rotation logic
+# ---------------------------------------------------------------------------
+
 def should_advance_rotation(rotation: ChoreRotation, now: datetime) -> bool:
     """Determine whether a rotation should advance to the next kid.
 
-    Returns True when enough calendar days have passed since the last
-    rotation based on the configured cadence.  We compare calendar
-    dates (not raw timedeltas) so that e.g. Monday 23:00 → Tuesday
-    00:01 correctly counts as 1 day for daily cadence.
+    Cadence semantics
+    -----------------
+    daily       — advance whenever a new calendar *day* begins.
+    weekly      — advance on every configured *rotation_day* boundary
+                  (default: Monday).  A rotation created on Thursday will
+                  advance for the first time the following rotation_day,
+                  giving the first kid a full period.
+    fortnightly — advance every *second* rotation_day boundary.
+    monthly     — advance when the calendar **month** changes.
     """
     if rotation.last_rotated is None:
         return True
 
     cadence = _cadence_value(rotation.cadence)
+    rday = _rotation_day(rotation)
 
     now_date = now.date() if hasattr(now, "date") else now
-    last_date = rotation.last_rotated.date() if hasattr(rotation.last_rotated, "date") else rotation.last_rotated
-    days_since = (now_date - last_date).days
+    last_date = (
+        rotation.last_rotated.date()
+        if hasattr(rotation.last_rotated, "date")
+        else rotation.last_rotated
+    )
 
-    thresholds = {
-        "daily": 1,
-        "weekly": 7,
-        "fortnightly": 14,
-        "monthly": 30,
-    }
-    return days_since >= thresholds.get(cadence, 7)
+    if cadence == "daily":
+        return (now_date - last_date).days >= 1
+
+    if cadence == "weekly":
+        return week_start_for(now_date, rday) > week_start_for(last_date, rday)
+
+    if cadence == "fortnightly":
+        return _boundaries_between(last_date, now_date, rday) >= 2
+
+    if cadence == "monthly":
+        return (now_date.year, now_date.month) > (last_date.year, last_date.month)
+
+    # Fallback: rolling 7-day window
+    return (now_date - last_date).days >= 7
 
 
 def advance_rotation(rotation: ChoreRotation, now: datetime) -> None:
@@ -44,27 +95,51 @@ def get_rotation_kid_for_day(
     active_weekdays: list[int] | None = None,
 ) -> int:
     """Return the kid ID that should be assigned on ``target_day``
-    given the rotation's current state.
+    given the rotation's current state as of ``reference_day``.
 
-    For daily cadence, the kid rotates each *occurrence* relative to
-    ``reference_day``.  When *active_weekdays* is supplied (e.g. from a
-    custom-days schedule), only those weekdays count as occurrences;
-    otherwise every calendar day counts.
-
-    For all other cadences, the same kid is used for the entire period.
+    Cadence projection
+    ------------------
+    daily       — one step per occurrence (or per configured weekday).
+    weekly      — one step per rotation-day boundary.
+    fortnightly — one step per two rotation-day boundaries.
+    monthly     — one step per calendar month.
     """
     cadence = _cadence_value(rotation.cadence)
+    rday = _rotation_day(rotation)
 
     if cadence == "daily":
         if active_weekdays is not None:
             offset = _count_occurrences(reference_day, target_day, active_weekdays)
         else:
             offset = (target_day - reference_day).days
-        idx = (rotation.current_index + offset) % len(rotation.kid_ids)
-    else:
-        idx = rotation.current_index
 
+    elif cadence == "weekly":
+        offset = _boundaries_between(reference_day, target_day, rday)
+
+    elif cadence == "fortnightly":
+        boundaries = _boundaries_between(reference_day, target_day, rday)
+        offset = boundaries // 2
+
+    elif cadence == "monthly":
+        months_ref = reference_day.year * 12 + reference_day.month
+        months_target = target_day.year * 12 + target_day.month
+        offset = months_target - months_ref
+
+    else:
+        offset = 0
+
+    idx = (rotation.current_index + offset) % len(rotation.kid_ids)
     return int(rotation.kid_ids[idx])
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+def _rotation_day(rotation: ChoreRotation) -> int:
+    """Safely read rotation_day from a rotation object (handles legacy rows
+    that don't have the column yet by defaulting to 0 / Monday)."""
+    return getattr(rotation, "rotation_day", None) or 0
 
 
 def _count_occurrences(start: date, end: date, weekdays: list[int]) -> int:

--- a/frontend/src/pages/ChoreDetail.jsx
+++ b/frontend/src/pages/ChoreDetail.jsx
@@ -34,6 +34,17 @@ const DIFFICULTY_COLORS = [
 ];
 const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
+// 0=Monday … 6=Sunday (matches Python's date.weekday())
+const ROTATION_DAYS = [
+  { value: 0, label: 'Monday' },
+  { value: 1, label: 'Tuesday' },
+  { value: 2, label: 'Wednesday' },
+  { value: 3, label: 'Thursday' },
+  { value: 4, label: 'Friday' },
+  { value: 5, label: 'Saturday' },
+  { value: 6, label: 'Sunday' },
+];
+
 const CATEGORY_COLORS = {
   cleaning: 'bg-accent/20 text-accent border-accent/40',
   cooking: 'bg-gold/20 text-gold border-gold/40',
@@ -100,7 +111,8 @@ export default function ChoreDetail() {
   // Rotation state (parent only)
   const [rotation, setRotation] = useState(null);
   const [allKids, setAllKids] = useState([]);
-  const [selectedCadence, setSelectedCadence] = useState('daily');
+  const [selectedCadence, setSelectedCadence] = useState('weekly');
+  const [selectedRotationDay, setSelectedRotationDay] = useState(0); // 0=Mon … 6=Sun
   const [assignmentRules, setAssignmentRules] = useState([]);
 
   const fetchRotation = useCallback(async () => {
@@ -219,7 +231,12 @@ export default function ChoreDetail() {
     try {
       await api('/api/rotations', {
         method: 'POST',
-        body: { chore_id: parseInt(id), kid_ids: allKids.map((k) => k.id), cadence: selectedCadence },
+        body: {
+          chore_id: parseInt(id),
+          kid_ids: allKids.map((k) => k.id),
+          cadence: selectedCadence,
+          rotation_day: selectedRotationDay,
+        },
       });
       await fetchRotation();
       setActionMessage('Rotation created.');
@@ -256,6 +273,23 @@ export default function ChoreDetail() {
       setActionMessage(`Cadence updated to ${newCadence}.`);
     } catch (err) {
       setActionMessage(err.message || 'Could not update cadence.');
+    } finally {
+      setActionLoading('');
+    }
+  };
+
+  const handleUpdateRotationDay = async (newDay) => {
+    if (!rotation) return;
+    setActionLoading('rotation');
+    try {
+      await api(`/api/rotations/${rotation.id}`, {
+        method: 'PUT',
+        body: { rotation_day: parseInt(newDay) },
+      });
+      await fetchRotation();
+      setActionMessage(`Rotation day updated.`);
+    } catch (err) {
+      setActionMessage(err.message || 'Could not update rotation day.');
     } finally {
       setActionLoading('');
     }
@@ -552,7 +586,11 @@ export default function ChoreDetail() {
                 </span>
                 's turn
               </span>
-              <span className="text-muted text-xs ml-auto capitalize">{rotation.cadence}</span>
+              <span className="text-muted text-xs ml-auto capitalize">
+                {rotation.cadence}
+                {(rotation.cadence === 'weekly' || rotation.cadence === 'fortnightly') &&
+                  ` · every ${ROTATION_DAYS[rotation.rotation_day ?? 0]?.label}`}
+              </span>
             </div>
           ) : (
             <div className="space-y-2">
@@ -598,19 +636,36 @@ export default function ChoreDetail() {
 
           {rotation ? (
             <div className="space-y-3">
-              <div className="flex items-center gap-2 text-sm">
-                <span className="text-muted">Cadence:</span>
-                <select
-                  value={rotation.cadence}
-                  onChange={(e) => handleUpdateCadence(e.target.value)}
-                  disabled={actionLoading === 'rotation'}
-                  className="bg-surface-raised text-cream text-sm rounded-md border border-border px-2 py-1 focus:outline-none focus:ring-1 focus:ring-purple"
-                >
-                  <option value="daily">Daily</option>
-                  <option value="weekly">Weekly</option>
-                  <option value="fortnightly">Fortnightly</option>
-                  <option value="monthly">Monthly</option>
-                </select>
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
+                <div className="flex items-center gap-2">
+                  <span className="text-muted">Cadence:</span>
+                  <select
+                    value={rotation.cadence}
+                    onChange={(e) => handleUpdateCadence(e.target.value)}
+                    disabled={actionLoading === 'rotation'}
+                    className="bg-surface-raised text-cream text-sm rounded-md border border-border px-2 py-1 focus:outline-none focus:ring-1 focus:ring-purple"
+                  >
+                    <option value="daily">Daily</option>
+                    <option value="weekly">Weekly</option>
+                    <option value="fortnightly">Fortnightly</option>
+                    <option value="monthly">Monthly</option>
+                  </select>
+                </div>
+                {(rotation.cadence === 'weekly' || rotation.cadence === 'fortnightly') && (
+                  <div className="flex items-center gap-2">
+                    <span className="text-muted">Rotates on:</span>
+                    <select
+                      value={rotation.rotation_day ?? 0}
+                      onChange={(e) => handleUpdateRotationDay(e.target.value)}
+                      disabled={actionLoading === 'rotation'}
+                      className="bg-surface-raised text-cream text-sm rounded-md border border-border px-2 py-1 focus:outline-none focus:ring-1 focus:ring-purple"
+                    >
+                      {ROTATION_DAYS.map((d) => (
+                        <option key={d.value} value={d.value}>{d.label}</option>
+                      ))}
+                    </select>
+                  </div>
+                )}
               </div>
               <div className="flex flex-wrap gap-2">
                 {(rotation.kid_ids || []).map((kidId, idx) => {
@@ -655,18 +710,34 @@ export default function ChoreDetail() {
               <p className="text-muted text-xs">
                 No rotation set. Create one to automatically rotate this quest between kids.
               </p>
-              <div className="flex items-center gap-2 text-sm">
-                <span className="text-muted">Cadence:</span>
-                <select
-                  value={selectedCadence}
-                  onChange={(e) => setSelectedCadence(e.target.value)}
-                  className="bg-surface-raised text-cream text-sm rounded-md border border-border px-2 py-1 focus:outline-none focus:ring-1 focus:ring-purple"
-                >
-                  <option value="daily">Daily</option>
-                  <option value="weekly">Weekly</option>
-                  <option value="fortnightly">Fortnightly</option>
-                  <option value="monthly">Monthly</option>
-                </select>
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
+                <div className="flex items-center gap-2">
+                  <span className="text-muted">Cadence:</span>
+                  <select
+                    value={selectedCadence}
+                    onChange={(e) => setSelectedCadence(e.target.value)}
+                    className="bg-surface-raised text-cream text-sm rounded-md border border-border px-2 py-1 focus:outline-none focus:ring-1 focus:ring-purple"
+                  >
+                    <option value="daily">Daily</option>
+                    <option value="weekly">Weekly</option>
+                    <option value="fortnightly">Fortnightly</option>
+                    <option value="monthly">Monthly</option>
+                  </select>
+                </div>
+                {(selectedCadence === 'weekly' || selectedCadence === 'fortnightly') && (
+                  <div className="flex items-center gap-2">
+                    <span className="text-muted">Rotates on:</span>
+                    <select
+                      value={selectedRotationDay}
+                      onChange={(e) => setSelectedRotationDay(parseInt(e.target.value))}
+                      className="bg-surface-raised text-cream text-sm rounded-md border border-border px-2 py-1 focus:outline-none focus:ring-1 focus:ring-purple"
+                    >
+                      {ROTATION_DAYS.map((d) => (
+                        <option key={d.value} value={d.value}>{d.label}</option>
+                      ))}
+                    </select>
+                  </div>
+                )}
               </div>
               <button
                 onClick={handleCreateRotation}

--- a/frontend/src/pages/ChoreDetail.jsx
+++ b/frontend/src/pages/ChoreDetail.jsx
@@ -534,35 +534,57 @@ export default function ChoreDetail() {
             <Users size={18} className="text-accent" />
             <h2 className="text-cream text-sm font-semibold">Assigned To</h2>
           </div>
-          <div className="space-y-2">
-            {assignmentRules.map((rule) => {
-              const kid = allKids.find((k) => k.id === rule.user_id);
-              return (
-                <div
-                  key={rule.id}
-                  className="flex items-center justify-between gap-3 px-3 py-2 rounded-md border border-border bg-surface-raised/20"
-                >
-                  <div className="flex items-center gap-2 min-w-0">
-                    <span className="text-cream text-sm font-medium truncate">
-                      {kid?.display_name || rule.user?.display_name || `Kid #${rule.user_id}`}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2 flex-shrink-0">
-                    <span className="text-muted text-xs capitalize flex items-center gap-1">
-                      <RefreshCw size={10} />
-                      {rule.recurrence}
-                    </span>
-                    {rule.requires_photo && (
-                      <span className="text-muted text-xs flex items-center gap-1">
-                        <Camera size={10} />
-                        Photo
+
+          {/* When a rotation is active, the rotation controls assignment —
+              show a single "currently" line instead of listing all kids,
+              which would falsely imply all of them do the chore at once. */}
+          {rotation ? (
+            <div className="flex items-center gap-2 px-3 py-2 rounded-md border border-purple/30 bg-purple/10">
+              <RotateCw size={14} className="text-purple flex-shrink-0" />
+              <span className="text-sm text-cream">
+                Rotation active — currently{' '}
+                <span className="font-semibold text-purple">
+                  {(() => {
+                    const currentKidId = rotation.kid_ids?.[rotation.current_index];
+                    const currentKid = allKids.find((k) => k.id === currentKidId);
+                    return currentKid?.display_name || `Kid #${currentKidId}`;
+                  })()}
+                </span>
+                's turn
+              </span>
+              <span className="text-muted text-xs ml-auto capitalize">{rotation.cadence}</span>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {assignmentRules.map((rule) => {
+                const kid = allKids.find((k) => k.id === rule.user_id);
+                return (
+                  <div
+                    key={rule.id}
+                    className="flex items-center justify-between gap-3 px-3 py-2 rounded-md border border-border bg-surface-raised/20"
+                  >
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className="text-cream text-sm font-medium truncate">
+                        {kid?.display_name || rule.user?.display_name || `Kid #${rule.user_id}`}
                       </span>
-                    )}
+                    </div>
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      <span className="text-muted text-xs capitalize flex items-center gap-1">
+                        <RefreshCw size={10} />
+                        {rule.recurrence}
+                      </span>
+                      {rule.requires_photo && (
+                        <span className="text-muted text-xs flex items-center gap-1">
+                          <Camera size={10} />
+                          Photo
+                        </span>
+                      )}
+                    </div>
                   </div>
-                </div>
-              );
-            })}
-          </div>
+                );
+              })}
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Three rotation fixes bundled together:

1. **First-kid skip fixed** — `last_rotated` is now set at creation time so the first kid isn't immediately skipped on the next daily reset.
2. **"Assigned To" panel** — when a rotation is active the panel now correctly shows _"Rotation active — currently [Kid]'s turn"_ instead of listing all kids as if they all do the chore at once.
3. **Calendar-week boundaries + configurable rotation day** — weekly/fortnightly rotations now advance on a hard calendar-week boundary (default: Monday) instead of a rolling 7-day window.  Parents can pick which day the rotation fires (Mon–Sun) via a new _"Rotates on:"_ dropdown — both at creation and while editing.

## Changes

| Layer | File | What changed |
|---|---|---|
| DB model | `backend/models.py` | Add `rotation_day: int = 0` to `ChoreRotation` |
| Migration | `backend/database.py` | Lightweight `ALTER TABLE ADD COLUMN rotation_day` |
| Schema | `backend/schemas.py` | `rotation_day` in Create / Update / Response |
| Router | `backend/routers/rotations.py` | Persist `rotation_day`; set `last_rotated` at creation; reset on day change |
| Service | `backend/services/rotation.py` | `week_start_for(d, rotation_day)` replaces hard-coded Monday; monthly = calendar-month boundary |
| UI | `frontend/src/pages/ChoreDetail.jsx` | "Rotates on:" picker for weekly/fortnightly; summary in Assigned To panel |

## Test plan

- [ ] Create a weekly rotation — verify "Rotates on:" defaults to Monday and Kid A is NOT skipped on first midnight reset
- [ ] Change "Rotates on:" to Wednesday — verify next advance fires on Wednesday, not 7 days from creation
- [ ] Fortnightly with Sunday — verify it advances every other Sunday
- [ ] Monthly — advances on the 1st of the new month
- [ ] Daily — unchanged behaviour
- [ ] Existing DB rows without `rotation_day` default to Monday with no errors
- [ ] "Assigned To" panel shows single-kid rotation status, not full kid list

🤖 Generated with [Claude Code](https://claude.com/claude-code)