### PR TITLE
fix: notification tap always refreshes kid's quest page

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -274,13 +274,20 @@ export default function Layout({ children }) {
                             key={n.id}
                             onClick={() => {
                               if (!n.is_read && !isTrade) markRead(n.id);
+                              setShowNotifs(false);
                               if (n.reference_type === 'kid_quest' && n.reference_id) {
-                                setShowNotifs(false);
                                 navigate(`/kids/${n.reference_id}`);
                               } else if (n.type === 'chore_completed') {
-                                setShowNotifs(false);
                                 navigate('/');
                               }
+                              // Force a data refresh on the target page — handles the case
+                              // where the parent is already on that page (React Router won't
+                              // remount) or missed the WebSocket event while their screen was off.
+                              setTimeout(() => {
+                                window.dispatchEvent(
+                                  new CustomEvent('ws:message', { detail: { type: 'data_changed' } })
+                                );
+                              }, 100);
                             }}
                             className={`w-full text-left px-4 py-3 border-b border-border/50 hover:bg-surface-raised transition-colors cursor-pointer ${
                               !n.is_read ? 'bg-accent/5' : ''


### PR DESCRIPTION
## Problem

When a parent taps a "Quest Awaiting Approval" notification:
1. If they're **already on `/kids/:id`** — React Router ignores the `navigate()` call (same route = no remount), so `fetchData()` never runs and the page stays stale showing old pending status
2. If they were on another page but their **browser missed the WebSocket event** (screen locked, background tab, brief network drop) — they'd see the old state until manually pull-to-refreshing

This caused parents to see kid 3's chores stuck as "pending" after the kid had already completed them and the notification had fired.

## Fix

Dispatch a `ws:message` custom event 100ms after the navigate call. Every data-fetching page (`KidQuests`, `ChoreDetail`, etc.) already listens to this event and calls its own `fetchData()` in response.  The 100ms delay lets React Router finish the navigation before the refresh fires.

## Test

1. Open `/kids/3` as a parent (see pending assignments)
2. As kid 3, complete a chore on another device/tab
3. Tap the "Quest Awaiting Approval" notification on the parent's device
4. The page should immediately show the updated **"Awaiting Approval"** status — no manual refresh needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)