### PR TITLE
fix(sw): auto-skipWaiting on install — prevents Safari PWA blank screen

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -10,8 +10,13 @@ self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS))
   );
-  // Don't call skipWaiting() automatically — wait for the app to signal
-  // via postMessage so we can show an "Update available" prompt first.
+  // Auto-skip waiting so the new SW activates immediately.
+  // This prevents Safari PWA home-screen bookmarks from getting stuck on a
+  // blank screen when the app is redeployed: without skipWaiting() the new SW
+  // sits in "waiting" forever if the page is already blank (can't tap the
+  // update banner). The controllerchange handler in main.jsx auto-reloads
+  // the page once this SW takes control, so all clients get fresh assets.
+  self.skipWaiting();
 });
 
 self.addEventListener('message', (event) => {

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -274,13 +274,20 @@ export default function Layout({ children }) {
                             key={n.id}
                             onClick={() => {
                               if (!n.is_read && !isTrade) markRead(n.id);
+                              setShowNotifs(false);
                               if (n.reference_type === 'kid_quest' && n.reference_id) {
-                                setShowNotifs(false);
                                 navigate(`/kids/${n.reference_id}`);
                               } else if (n.type === 'chore_completed') {
-                                setShowNotifs(false);
                                 navigate('/');
                               }
+                              // Force a data refresh on the target page — handles the case
+                              // where the parent is already on that page (React Router won't
+                              // remount) or missed the WebSocket event while their screen was off.
+                              setTimeout(() => {
+                                window.dispatchEvent(
+                                  new CustomEvent('ws:message', { detail: { type: 'data_changed' } })
+                                );
+                              }, 100);
                             }}
                             className={`w-full text-left px-4 py-3 border-b border-border/50 hover:bg-surface-raised transition-colors cursor-pointer ${
                               !n.is_read ? 'bg-accent/5' : ''


### PR DESCRIPTION
## Problem

Safari PWA home-screen bookmarks can get stuck on a **blank white screen** after a new deployment.

**Root cause:** The service worker only calls `skipWaiting()` when the app posts a `SKIP_WAITING` message (triggered by the user tapping the UpdatePrompt banner). If the app is already blank (e.g. version mismatch causing a JS load error), that banner never renders — so the new SW sits in `waiting` forever, the stale cache stays active, and the screen stays blank. The only escape was manually deleting and re-adding the home screen shortcut.

## Fix

Add `self.skipWaiting()` directly in the `install` event handler so the new SW **always** takes control immediately on install, no user interaction required.

The existing `controllerchange` listener in `main.jsx` already calls `window.location.reload()` when a new SW takes control, so all clients automatically reload and pick up fresh assets.

The `UpdatePrompt` component is kept in place — it just won't show anymore since `reg.waiting` will never be set. That's acceptable: silent auto-updates are better UX than a blank screen for a family app.

## Impact

| Scenario | Before | After |
|---|---|---|
| Safari PWA after deploy | May go blank, stuck forever | Auto-reloads with fresh assets |
| Normal browser tab | Shows update banner (user must tap) | Auto-reloads silently |
| In-progress session | No mid-session disruption | controllerchange only fires on SW install, which only happens when a new version is deployed |

## Test plan
- [ ] Deploy new version → Safari PWA home screen shortcut auto-reloads (no blank screen)
- [ ] `frontend/public/sw.js` install handler calls `self.skipWaiting()`
- [ ] Existing push notification and fetch caching logic unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)