### PR TITLE
fix: Complete Quest button never showed on ChoreDetail for kids

### DIFF
--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -429,7 +429,9 @@ async def get_chore(
     response = ChoreResponse.model_validate(chore)
     summaries = await _build_rotation_summaries(db, [chore_id])
     updates: dict = {"rotation_summary": summaries.get(chore_id)}
-    # Apply per-kid requires_photo rule override when a kid fetches the chore
+    # Apply per-kid requires_photo rule override when a kid fetches the chore,
+    # and include the kid's recent assignments so ChoreDetail can determine
+    # hasPendingToday and show the Complete Quest button.
     if user.role == UserRole.kid:
         rule_result = await db.execute(
             select(ChoreAssignmentRule).where(
@@ -441,6 +443,33 @@ async def get_chore(
         rule = rule_result.scalar_one_or_none()
         if rule is not None:
             updates["requires_photo"] = rule.requires_photo
+
+        # Load this kid's assignments for this chore (today + last 7 days)
+        # so the frontend knows whether a pending assignment exists today.
+        today = date.today()
+        week_ago = today - timedelta(days=7)
+        a_result = await db.execute(
+            select(ChoreAssignment)
+            .where(
+                ChoreAssignment.chore_id == chore_id,
+                ChoreAssignment.user_id == user.id,
+                ChoreAssignment.date >= week_ago,
+                ChoreAssignment.date <= today,
+            )
+            .order_by(ChoreAssignment.date.desc())
+        )
+        kid_assignments = a_result.scalars().all()
+        updates["assignments"] = [
+            {
+                "id": a.id,
+                "date": a.date.isoformat(),
+                "status": a.status.value,
+                "completed_at": a.completed_at.isoformat() if a.completed_at else None,
+                "verified_at": a.verified_at.isoformat() if a.verified_at else None,
+                "photo_proof_path": a.photo_proof_path,
+            }
+            for a in kid_assignments
+        ]
     return response.model_copy(update=updates)
 
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -132,6 +132,9 @@ class ChoreResponse(BaseModel):
     created_by: int
     created_at: datetime
     rotation_summary: RotationSummary | None = None
+    # Populated by GET /api/chores/{id} when the requester is a kid so
+    # ChoreDetail can show the Complete Quest button without a second API call.
+    assignments: list[dict] | None = None
 
     model_config = {"from_attributes": True}
 


### PR DESCRIPTION
## Root cause

`ChoreResponse` schema had no `assignments` field. When a kid fetched `GET /api/chores/{id}`, the response contained no assignment data.

In `ChoreDetail.jsx`:
```js
const assignments = chore.assignments || chore.history || [];
// → always []

const hasPendingToday = todayAssignment && todayAssignment.status === 'pending';
// → always false

{isKid && hasPendingToday && (
  <button>Complete Quest</button>  // ← never rendered
)}
```

Kids could only complete chores from the **KidDashboard inline buttons**, not from the chore detail page. If a kid tapped a notification link (which goes to `/chores/:id`), there was no Complete button — it looked like the chore couldn't be completed.

This is why Kai (kid 3) had 138 pending assignments and 0 completed: they were using ChoreDetail and the button simply wasn't there.

## Fix

When a kid calls `GET /api/chores/{id}`, the endpoint now fetches their `ChoreAssignment` rows for the past 7 days and attaches them as `assignments` in the response. `ChoreDetail.jsx` then correctly computes `hasPendingToday = true` and renders the Complete Quest button.

Added `assignments: list[dict] | None = None` to `ChoreResponse` schema (optional — parents get `null`, kids get their assignment list).

## Test plan
- [ ] Kid opens a chore detail page → Complete Quest button visible for pending chores
- [ ] Tapping Complete Quest fires the completion and the button disappears
- [ ] Parent sees the completed assignment on `/kids/{id}` for approval
- [ ] Photo-required chores: button still disabled until file selected
- [ ] Parent chore detail view unchanged (no assignments in response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)