### PR TITLE
fix(security): bump python-multipart, gate /debug endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,7 @@ TZ=America/Chicago
 
 # Optional — GitHub repo for in-app update checks (default: turbogizzmo/ChoreQuest)
 # GITHUB_REPO=yourusername/ChoreQuest
+
+# Optional — expose internal /debug endpoints (dev only, default: false)
+# When false, /api/chores/{id}/debug returns 404 even to authenticated parents
+# ENABLE_DEBUG_ENDPOINTS=true

--- a/backend/config.py
+++ b/backend/config.py
@@ -20,6 +20,8 @@ class Settings(BaseSettings):
     VAPID_PRIVATE_KEY: str = ""
     VAPID_PUBLIC_KEY: str = ""
     VAPID_CLAIM_EMAIL: str = "mailto:admin@example.com"
+    # Set ENABLE_DEBUG_ENDPOINTS=true to expose internal /debug routes (dev only)
+    ENABLE_DEBUG_ENDPOINTS: bool = False
 
     model_config = {"env_file": ".env", "extra": "ignore"}
 

--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -795,7 +795,14 @@ async def debug_chore(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(require_parent),
 ):
-    """Debug endpoint: show all DB state for a chore's rotation/assignments."""
+    """Debug endpoint: show all DB state for a chore's rotation/assignments.
+
+    Disabled in production by default. Set ENABLE_DEBUG_ENDPOINTS=true in
+    the environment to expose this route. Even when enabled, parent auth
+    is still required.
+    """
+    if not settings.ENABLE_DEBUG_ENDPOINTS:
+        raise HTTPException(status_code=404, detail="Not found")
     chore = await _get_chore_or_404(db, chore_id, active_only=False)
 
     rot_result = await db.execute(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ aiosqlite==0.20.0
 pydantic==2.10.4
 pydantic-settings==2.7.1
 bcrypt==4.2.1
-python-multipart==0.0.20
+python-multipart==0.0.26
 pywebpush==2.3.0
 cryptography==47.0.0


### PR DESCRIPTION
## Summary
- Bump `python-multipart` 0.0.20 → 0.0.26 (closes 2 Dependabot alerts: 1 HIGH, 1 MEDIUM)
- Gate `/api/chores/{id}/debug` behind new `ENABLE_DEBUG_ENDPOINTS` env flag (defaults off → returns 404 in production)
- Document the flag in `.env.example`

## Why
- **HIGH** alert: arbitrary file write via non-default `python-multipart` config (fixed in 0.0.22)
- **MEDIUM** alert: DoS via large multipart preamble/epilogue (fixed in 0.0.26)
- The debug endpoint exposes raw DB state (rotation, rules, assignments) — not a vulnerability since it requires parent auth, but unnecessary attack surface in prod

## Test plan
- [x] CI: backend unit tests + 192 e2e Playwright tests must pass
- [x] Verify default behavior: `/api/chores/{id}/debug` returns 404 with parent token
- [x] With `ENABLE_DEBUG_ENDPOINTS=true`: endpoint returns DB dump with parent token

🤖 Generated with [Claude Code](https://claude.com/claude-code)