### PR TITLE
Show pending bounty claims on parent home screen with dates

### DIFF
--- a/backend/routers/bounty.py
+++ b/backend/routers/bounty.py
@@ -36,11 +36,19 @@ _WS_BOUNTY_CHANGED = {"type": "data_changed", "data": {"entity": "bounty"}}
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _build_claim(claim: BountyBoardClaim, user: User | None = None, chore_title: str | None = None) -> BountyClaimResponse:
+def _build_claim(
+    claim: BountyBoardClaim,
+    user: User | None = None,
+    chore_title: str | None = None,
+    chore_points: int | None = None,
+    chore_requires_photo: bool = False,
+) -> BountyClaimResponse:
     return BountyClaimResponse(
         id=claim.id,
         chore_id=claim.chore_id,
         chore_title=chore_title,
+        chore_points=chore_points,
+        chore_requires_photo=chore_requires_photo,
         user_id=claim.user_id,
         user_display_name=user.display_name if user else None,
         status=claim.status,
@@ -64,12 +72,12 @@ def _build_bounty(
         is_default=cat.is_default,
     ) if cat else None
 
-    my_claim_resp = _build_claim(my_claim, chore_title=chore.title) if my_claim else None
+    my_claim_resp = _build_claim(my_claim, chore_title=chore.title, chore_points=chore.points, chore_requires_photo=chore.requires_photo) if my_claim else None
 
     active_statuses = {BountyClaimStatus.claimed, BountyClaimStatus.completed, BountyClaimStatus.verified}
     claim_count = sum(1 for c, _ in all_claims if c.status in active_statuses)
 
-    claims_resp = [_build_claim(c, u, chore_title=chore.title) for c, u in all_claims]
+    claims_resp = [_build_claim(c, u, chore_title=chore.title, chore_points=chore.points, chore_requires_photo=chore.requires_photo) for c, u in all_claims]
 
     return BountyResponse(
         id=chore.id,
@@ -381,7 +389,15 @@ async def list_pending_claims(
         .where(BountyBoardClaim.status == BountyClaimStatus.completed)
         .order_by(BountyBoardClaim.completed_at.desc())
     )
-    return [_build_claim(claim, user, chore_title=chore.title if chore else None) for claim, user, chore in result.all()]
+    return [
+        _build_claim(
+            claim, user,
+            chore_title=chore.title if chore else None,
+            chore_points=chore.points if chore else None,
+            chore_requires_photo=chore.requires_photo if chore else False,
+        )
+        for claim, user, chore in result.all()
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -596,6 +596,8 @@ class BountyClaimResponse(BaseModel):
     id: int
     chore_id: int
     chore_title: str | None = None  # injected by router so Review Claims always has a title
+    chore_points: int | None = None
+    chore_requires_photo: bool = False
     user_id: int
     user_display_name: str | None = None
     status: BountyClaimStatus

--- a/frontend/src/pages/ParentDashboard.jsx
+++ b/frontend/src/pages/ParentDashboard.jsx
@@ -36,11 +36,17 @@ function getDateLabel(dateStr) {
   return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
 }
 
+/** Normalize a backend UTC datetime string to a proper UTC Date (appends 'Z' if missing). */
+function parseUtcDate(dtStr) {
+  if (!dtStr) return null;
+  const utcStr = /Z|[+-]\d\d:?\d\d$/.test(dtStr) ? dtStr : dtStr + 'Z';
+  return new Date(utcStr);
+}
+
 /** Convert a UTC datetime string from the backend to a local YYYY-MM-DD string. */
 function utcToLocalDateISO(dtStr) {
-  if (!dtStr) return '';
-  const utcStr = /Z|[+-]\d\d:?\d\d$/.test(dtStr) ? dtStr : dtStr + 'Z';
-  return toLocalISO(new Date(utcStr));
+  const d = parseUtcDate(dtStr);
+  return d ? toLocalISO(d) : '';
 }
 
 export default function ParentDashboard() {
@@ -475,7 +481,7 @@ export default function ParentDashboard() {
                           </span>
                           {claim.completed_at && (
                             <span className="text-muted ml-1">
-                              · submitted {new Date(/Z|[+-]\d\d:?\d\d$/.test(claim.completed_at) ? claim.completed_at : claim.completed_at + 'Z').toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
+                              · submitted {parseUtcDate(claim.completed_at).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
                             </span>
                           )}
                         </p>

--- a/frontend/src/pages/ParentDashboard.jsx
+++ b/frontend/src/pages/ParentDashboard.jsx
@@ -15,6 +15,7 @@ import {
   MessageSquare,
   Send,
   CalendarDays,
+  Swords,
 } from 'lucide-react';
 import { useTheme } from '../hooks/useTheme';
 import { themedTitle } from '../utils/questThemeText';
@@ -35,6 +36,13 @@ function getDateLabel(dateStr) {
   return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
 }
 
+/** Convert a UTC datetime string from the backend to a local YYYY-MM-DD string. */
+function utcToLocalDateISO(dtStr) {
+  if (!dtStr) return '';
+  const utcStr = /Z|[+-]\d\d:?\d\d$/.test(dtStr) ? dtStr : dtStr + 'Z';
+  return toLocalISO(new Date(utcStr));
+}
+
 export default function ParentDashboard() {
   const { user } = useAuth();
   const navigate = useNavigate();
@@ -42,6 +50,7 @@ export default function ParentDashboard() {
 
   const [familyStats, setFamilyStats] = useState([]);
   const [pendingVerifications, setPendingVerifications] = useState([]);
+  const [pendingBountyClaims, setPendingBountyClaims] = useState([]);
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -61,9 +70,10 @@ export default function ParentDashboard() {
     try {
       setError(null);
 
-      const [familyRes, calendarRes] = await Promise.all([
+      const [familyRes, calendarRes, bountyClaimsRes] = await Promise.all([
         api('/api/stats/family'),
         api('/api/calendar'),
+        api('/api/bounty/claims'),
       ]);
 
       setFamilyStats(familyRes);
@@ -75,6 +85,7 @@ export default function ParentDashboard() {
         .filter((a) => a.status === 'completed')
         .sort((a, b) => b.date.localeCompare(a.date));
       setPendingVerifications(needsVerification);
+      setPendingBountyClaims(bountyClaimsRes || []);
     } catch (err) {
       setError(err.message || 'Failed to load family data');
     } finally {
@@ -117,6 +128,32 @@ export default function ParentDashboard() {
       await fetchData();
     } catch (err) {
       setError(err.message || 'Failed to reject chore');
+    } finally {
+      setActionBusy(key, false);
+    }
+  };
+
+  const handleVerifyBounty = async (claimId) => {
+    const key = `bounty-verify-${claimId}`;
+    setActionBusy(key, true);
+    try {
+      await api(`/api/bounty/claims/${claimId}/verify`, { method: 'POST' });
+      await fetchData();
+    } catch (err) {
+      setError(err.message || 'Failed to verify bounty');
+    } finally {
+      setActionBusy(key, false);
+    }
+  };
+
+  const handleRejectBounty = async (claimId) => {
+    const key = `bounty-reject-${claimId}`;
+    setActionBusy(key, true);
+    try {
+      await api(`/api/bounty/claims/${claimId}/reject`, { method: 'POST' });
+      await fetchData();
+    } catch (err) {
+      setError(err.message || 'Failed to reject bounty');
     } finally {
       setActionBusy(key, false);
     }
@@ -191,7 +228,7 @@ export default function ParentDashboard() {
     );
   }
 
-  const hasPendingItems = pendingVerifications.length > 0;
+  const hasPendingItems = pendingVerifications.length > 0 || pendingBountyClaims.length > 0;
 
   return (
     <div className="max-w-3xl mx-auto space-y-4">
@@ -387,6 +424,101 @@ export default function ParentDashboard() {
                     <p className="mt-1.5 ml-5 text-muted text-xs italic">
                       Feedback: {assignment.feedback}
                     </p>
+                  )}
+                </div>
+              );
+            })}
+
+            {pendingBountyClaims.map((claim) => {
+              const verifyKey = `bounty-verify-${claim.id}`;
+              const rejectKey = `bounty-reject-${claim.id}`;
+              const isVerifying = actionLoading[verifyKey];
+              const isRejecting = actionLoading[rejectKey];
+              const isBusy = isVerifying || isRejecting;
+              const claimDate = utcToLocalDateISO(claim.completed_at);
+              const isToday = claimDate === todayLocalISO();
+
+              return (
+                <div
+                  key={`bounty-${claim.id}`}
+                  className="game-panel p-3"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <p
+                          className="text-cream text-sm font-medium truncate cursor-pointer hover:text-accent transition-colors"
+                          onClick={() => navigate(`/bounty`)}
+                        >
+                          {themedTitle(claim.chore_title || 'Bounty', colorTheme)}
+                        </p>
+                        <span className="inline-flex items-center gap-1 text-purple-400 text-xs font-medium flex-shrink-0">
+                          <Swords size={10} /> Bounty
+                        </span>
+                      </div>
+                      <p className="text-muted text-xs mt-0.5">
+                        by {claim.user_display_name || 'Kid'}
+                        {claim.chore_requires_photo && (
+                          <span className="inline-flex items-center gap-1 ml-2 text-accent">
+                            <Camera size={10} /> Photo
+                          </span>
+                        )}
+                        {claim.chore_points != null && (
+                          <span className="ml-2 text-gold font-medium">+{claim.chore_points} XP</span>
+                        )}
+                      </p>
+                      {claimDate && (
+                        <p className="flex items-center gap-1 text-xs mt-1">
+                          <CalendarDays size={11} className={isToday ? 'text-accent' : 'text-orange-400'} />
+                          <span className={isToday ? 'text-accent font-medium' : 'text-orange-400 font-medium'}>
+                            {getDateLabel(claimDate)}
+                          </span>
+                          {claim.completed_at && (
+                            <span className="text-muted ml-1">
+                              · submitted {new Date(/Z|[+-]\d\d:?\d\d$/.test(claim.completed_at) ? claim.completed_at : claim.completed_at + 'Z').toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
+                            </span>
+                          )}
+                        </p>
+                      )}
+                      {claim.kid_note && (
+                        <p className="mt-1 text-muted text-xs italic">"{claim.kid_note}"</p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1.5 flex-shrink-0">
+                      <button
+                        className="game-btn game-btn-blue !px-2.5 !py-1.5"
+                        disabled={isBusy}
+                        onClick={() => handleVerifyBounty(claim.id)}
+                        title="Approve"
+                      >
+                        {isVerifying ? (
+                          <Loader2 size={14} className="animate-spin" />
+                        ) : (
+                          <CheckCircle2 size={14} />
+                        )}
+                      </button>
+                      <button
+                        className="game-btn game-btn-red !px-2.5 !py-1.5"
+                        disabled={isBusy}
+                        onClick={() => handleRejectBounty(claim.id)}
+                        title="Reject"
+                      >
+                        {isRejecting ? (
+                          <Loader2 size={14} className="animate-spin" />
+                        ) : (
+                          <XCircle size={14} />
+                        )}
+                      </button>
+                    </div>
+                  </div>
+                  {claim.photo_proof_path && (
+                    <div className="mt-2">
+                      <img
+                        src={`/api/uploads/${claim.photo_proof_path}`}
+                        alt="Photo proof"
+                        className="rounded-md max-h-48 object-cover border border-border"
+                      />
+                    </div>
                   )}
                 </div>
               );


### PR DESCRIPTION
## Summary
- Pending bounty claims (status: `completed`, awaiting parent approval) now appear in the **Pending Verifications** section on the parent home screen alongside regular chore approvals
- Each bounty card shows a purple **Bounty** badge (sword icon) so parents can tell them apart from regular chores
- Date labels ("Today" / "Yesterday" / weekday) and submission time are displayed, using the claim's `completed_at` timestamp converted to local time
- Kid's note is shown if they left one; photo proof displays inline if attached
- Approve/Reject buttons call the existing bounty claim endpoints (`/api/bounty/claims/{id}/verify` and `/api/bounty/claims/{id}/reject`)
- Added `chore_points` and `chore_requires_photo` to `BountyClaimResponse` so the dashboard can show XP reward and photo indicator without an extra fetch

## Test plan
- [ ] Complete a bounty as a kid — verify the claim card appears on the parent home screen under Pending Verifications
- [ ] Confirm the **Bounty** badge is visible and the date label shows "Today"
- [ ] Complete a bounty yesterday — confirm "Yesterday" label appears
- [ ] Approve a bounty from the home screen — verify XP is awarded and the card disappears
- [ ] Reject a bounty from the home screen — verify the claim reverts and the card disappears
- [ ] Confirm regular chore approvals still work and display correctly alongside bounty cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)