### PR TITLE
Fix update overlay not showing on fresh page load during an update

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -202,8 +202,11 @@ app.include_router(public.router)
 @app.get("/api/health")
 async def health():
     import os
+    from pathlib import Path
+    updating = Path("/app/data/.update_in_progress").exists()
     return {
-        "status": "ok",
+        "status": "updating" if updating else "ok",
+        "updating": updating,
         "version": os.environ.get("GIT_COMMIT", "unknown"),
         "build_date": os.environ.get("BUILD_DATE", "unknown"),
     }

--- a/backend/routers/bounty.py
+++ b/backend/routers/bounty.py
@@ -235,7 +235,7 @@ async def claim_bounty(
             await db.commit()
             await db.refresh(existing_claim)
             await ws_manager.broadcast(_WS_BOUNTY_CHANGED)
-            return _build_claim(existing_claim)
+            return _build_claim(existing_claim, current_user, chore_title=chore.title, chore_points=chore.points, chore_requires_photo=chore.requires_photo)
         raise HTTPException(status_code=409, detail="You have already claimed this bounty")
 
     claim = BountyBoardClaim(
@@ -263,7 +263,7 @@ async def claim_bounty(
     await db.commit()
     await db.refresh(claim)
     await ws_manager.broadcast(_WS_BOUNTY_CHANGED)
-    return _build_claim(claim)
+    return _build_claim(claim, current_user, chore_title=chore.title, chore_points=chore.points, chore_requires_photo=chore.requires_photo)
 
 
 # ---------------------------------------------------------------------------
@@ -338,7 +338,7 @@ async def complete_bounty(
     await db.commit()
     await db.refresh(claim)
     await ws_manager.broadcast(_WS_BOUNTY_CHANGED)
-    return _build_claim(claim)
+    return _build_claim(claim, current_user, chore_title=chore.title if chore else None, chore_points=chore.points if chore else None, chore_requires_photo=chore.requires_photo if chore else False)
 
 
 # ---------------------------------------------------------------------------
@@ -544,7 +544,7 @@ async def verify_bounty_claim(
     })
     await ws_manager.broadcast(_WS_BOUNTY_CHANGED)
 
-    return _build_claim(claim)
+    return _build_claim(claim, kid, chore_title=chore.title, chore_points=chore.points, chore_requires_photo=chore.requires_photo)
 
 
 # ---------------------------------------------------------------------------
@@ -595,7 +595,7 @@ async def reject_bounty_claim(
     await db.commit()
     await db.refresh(claim)
     await ws_manager.broadcast(_WS_BOUNTY_CHANGED)
-    return _build_claim(claim)
+    return _build_claim(claim, chore_title=chore.title if chore else None, chore_points=chore.points if chore else None, chore_requires_photo=chore.requires_photo if chore else False)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/routers/bounty.py
+++ b/backend/routers/bounty.py
@@ -36,11 +36,19 @@ _WS_BOUNTY_CHANGED = {"type": "data_changed", "data": {"entity": "bounty"}}
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _build_claim(claim: BountyBoardClaim, user: User | None = None, chore_title: str | None = None) -> BountyClaimResponse:
+def _build_claim(
+    claim: BountyBoardClaim,
+    user: User | None = None,
+    chore_title: str | None = None,
+    chore_points: int | None = None,
+    chore_requires_photo: bool = False,
+) -> BountyClaimResponse:
     return BountyClaimResponse(
         id=claim.id,
         chore_id=claim.chore_id,
         chore_title=chore_title,
+        chore_points=chore_points,
+        chore_requires_photo=chore_requires_photo,
         user_id=claim.user_id,
         user_display_name=user.display_name if user else None,
         status=claim.status,
@@ -64,12 +72,12 @@ def _build_bounty(
         is_default=cat.is_default,
     ) if cat else None
 
-    my_claim_resp = _build_claim(my_claim, chore_title=chore.title) if my_claim else None
+    my_claim_resp = _build_claim(my_claim, chore_title=chore.title, chore_points=chore.points, chore_requires_photo=chore.requires_photo) if my_claim else None
 
     active_statuses = {BountyClaimStatus.claimed, BountyClaimStatus.completed, BountyClaimStatus.verified}
     claim_count = sum(1 for c, _ in all_claims if c.status in active_statuses)
 
-    claims_resp = [_build_claim(c, u, chore_title=chore.title) for c, u in all_claims]
+    claims_resp = [_build_claim(c, u, chore_title=chore.title, chore_points=chore.points, chore_requires_photo=chore.requires_photo) for c, u in all_claims]
 
     return BountyResponse(
         id=chore.id,
@@ -381,7 +389,15 @@ async def list_pending_claims(
         .where(BountyBoardClaim.status == BountyClaimStatus.completed)
         .order_by(BountyBoardClaim.completed_at.desc())
     )
-    return [_build_claim(claim, user, chore_title=chore.title if chore else None) for claim, user, chore in result.all()]
+    return [
+        _build_claim(
+            claim, user,
+            chore_title=chore.title if chore else None,
+            chore_points=chore.points if chore else None,
+            chore_requires_photo=chore.requires_photo if chore else False,
+        )
+        for claim, user, chore in result.all()
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -596,6 +596,8 @@ class BountyClaimResponse(BaseModel):
     id: int
     chore_id: int
     chore_title: str | None = None  # injected by router so Review Claims always has a title
+    chore_points: int | None = None
+    chore_requires_photo: bool = False
     user_id: int
     user_display_name: str | None = None
     status: BountyClaimStatus

--- a/frontend/src/components/UpdateOverlay.jsx
+++ b/frontend/src/components/UpdateOverlay.jsx
@@ -135,6 +135,11 @@ export default function UpdateOverlay() {
 
         if (bgVersionRef.current === null) {
           bgVersionRef.current = v; // baseline on first check
+          // Fresh page load during an in-progress update: the lock file exists
+          // on disk so the health endpoint returns updating:true.  Show the
+          // overlay immediately — the WS broadcast already happened before this
+          // device connected so it was never received.
+          if (data?.updating) showOverlay(v);
           return;
         }
 

--- a/frontend/src/components/UpdateOverlay.jsx
+++ b/frontend/src/components/UpdateOverlay.jsx
@@ -86,6 +86,11 @@ export default function UpdateOverlay() {
   // that is the definitive "container restarted" signal even when GIT_COMMIT
   // is "unknown" on both old and new builds.
   const serverWentDownRef       = useRef(false);
+  // Set when the overlay is triggered by the lock-file flag (updating:true on
+  // fresh load).  In this case the container may already be the new one, so we
+  // dismiss once the lock file is gone (updating:false) rather than waiting for
+  // a version change or a server-down event that will never happen.
+  const triggeredByLockFileRef  = useRef(false);
   // Passive background monitor — tracks baseline version so we can detect
   // a restart even when the WS broadcast was missed (mobile sleeping tab).
   const bgVersionRef            = useRef(null);
@@ -95,10 +100,11 @@ export default function UpdateOverlay() {
   // ------------------------------------------------------------------
   // Show overlay — shared handler used by both trigger sources below.
   // ------------------------------------------------------------------
-  const showOverlay = (currentVersion) => {
-    startVersionRef.current   = currentVersion ?? null;
-    startTimeRef.current      = Date.now();
-    serverWentDownRef.current = false;
+  const showOverlay = (currentVersion, { fromLockFile = false } = {}) => {
+    startVersionRef.current        = currentVersion ?? null;
+    startTimeRef.current           = Date.now();
+    serverWentDownRef.current      = false;
+    triggeredByLockFileRef.current = fromLockFile;
     setPercent(0);
     setDone(false);
     setTimedOut(false);
@@ -139,7 +145,7 @@ export default function UpdateOverlay() {
           // on disk so the health endpoint returns updating:true.  Show the
           // overlay immediately — the WS broadcast already happened before this
           // device connected so it was never received.
-          if (data?.updating) showOverlay(v);
+          if (data?.updating) showOverlay(v, { fromLockFile: true });
           return;
         }
 
@@ -260,6 +266,15 @@ export default function UpdateOverlay() {
         // Phase 2: server went offline then came back — container restarted.
         // Reliable even when GIT_COMMIT is "unknown" on both old and new builds.
         if (serverWentDownRef.current) {
+          completeUpdate();
+          return;
+        }
+
+        // Phase 3: overlay was triggered by the lock file on fresh load.
+        // The container may have already restarted before we connected, so
+        // version won't change and the server may never go down.  Dismiss
+        // as soon as the watchdog removes the lock file (updating:false).
+        if (triggeredByLockFileRef.current && !data?.updating) {
           completeUpdate();
           return;
         }

--- a/frontend/src/pages/ParentDashboard.jsx
+++ b/frontend/src/pages/ParentDashboard.jsx
@@ -36,11 +36,17 @@ function getDateLabel(dateStr) {
   return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
 }
 
+/** Normalize a backend UTC datetime string to a proper UTC Date (appends 'Z' if missing). */
+function parseUtcDate(dtStr) {
+  if (!dtStr) return null;
+  const utcStr = /Z|[+-]\d\d:?\d\d$/.test(dtStr) ? dtStr : dtStr + 'Z';
+  return new Date(utcStr);
+}
+
 /** Convert a UTC datetime string from the backend to a local YYYY-MM-DD string. */
 function utcToLocalDateISO(dtStr) {
-  if (!dtStr) return '';
-  const utcStr = /Z|[+-]\d\d:?\d\d$/.test(dtStr) ? dtStr : dtStr + 'Z';
-  return toLocalISO(new Date(utcStr));
+  const d = parseUtcDate(dtStr);
+  return d ? toLocalISO(d) : '';
 }
 
 export default function ParentDashboard() {
@@ -475,7 +481,7 @@ export default function ParentDashboard() {
                           </span>
                           {claim.completed_at && (
                             <span className="text-muted ml-1">
-                              · submitted {new Date(/Z|[+-]\d\d:?\d\d$/.test(claim.completed_at) ? claim.completed_at : claim.completed_at + 'Z').toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
+                              · submitted {parseUtcDate(claim.completed_at).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
                             </span>
                           )}
                         </p>

--- a/frontend/src/pages/ParentDashboard.jsx
+++ b/frontend/src/pages/ParentDashboard.jsx
@@ -15,6 +15,7 @@ import {
   MessageSquare,
   Send,
   CalendarDays,
+  Swords,
 } from 'lucide-react';
 import { useTheme } from '../hooks/useTheme';
 import { themedTitle } from '../utils/questThemeText';
@@ -35,6 +36,13 @@ function getDateLabel(dateStr) {
   return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
 }
 
+/** Convert a UTC datetime string from the backend to a local YYYY-MM-DD string. */
+function utcToLocalDateISO(dtStr) {
+  if (!dtStr) return '';
+  const utcStr = /Z|[+-]\d\d:?\d\d$/.test(dtStr) ? dtStr : dtStr + 'Z';
+  return toLocalISO(new Date(utcStr));
+}
+
 export default function ParentDashboard() {
   const { user } = useAuth();
   const navigate = useNavigate();
@@ -42,6 +50,7 @@ export default function ParentDashboard() {
 
   const [familyStats, setFamilyStats] = useState([]);
   const [pendingVerifications, setPendingVerifications] = useState([]);
+  const [pendingBountyClaims, setPendingBountyClaims] = useState([]);
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -61,9 +70,10 @@ export default function ParentDashboard() {
     try {
       setError(null);
 
-      const [familyRes, calendarRes] = await Promise.all([
+      const [familyRes, calendarRes, bountyClaimsRes] = await Promise.all([
         api('/api/stats/family'),
         api('/api/calendar'),
+        api('/api/bounty/claims'),
       ]);
 
       setFamilyStats(familyRes);
@@ -75,6 +85,7 @@ export default function ParentDashboard() {
         .filter((a) => a.status === 'completed')
         .sort((a, b) => b.date.localeCompare(a.date));
       setPendingVerifications(needsVerification);
+      setPendingBountyClaims(bountyClaimsRes || []);
     } catch (err) {
       setError(err.message || 'Failed to load family data');
     } finally {
@@ -117,6 +128,32 @@ export default function ParentDashboard() {
       await fetchData();
     } catch (err) {
       setError(err.message || 'Failed to reject chore');
+    } finally {
+      setActionBusy(key, false);
+    }
+  };
+
+  const handleVerifyBounty = async (claimId) => {
+    const key = `bounty-verify-${claimId}`;
+    setActionBusy(key, true);
+    try {
+      await api(`/api/bounty/claims/${claimId}/verify`, { method: 'POST' });
+      await fetchData();
+    } catch (err) {
+      setError(err.message || 'Failed to verify bounty');
+    } finally {
+      setActionBusy(key, false);
+    }
+  };
+
+  const handleRejectBounty = async (claimId) => {
+    const key = `bounty-reject-${claimId}`;
+    setActionBusy(key, true);
+    try {
+      await api(`/api/bounty/claims/${claimId}/reject`, { method: 'POST' });
+      await fetchData();
+    } catch (err) {
+      setError(err.message || 'Failed to reject bounty');
     } finally {
       setActionBusy(key, false);
     }
@@ -191,7 +228,7 @@ export default function ParentDashboard() {
     );
   }
 
-  const hasPendingItems = pendingVerifications.length > 0;
+  const hasPendingItems = pendingVerifications.length > 0 || pendingBountyClaims.length > 0;
 
   return (
     <div className="max-w-3xl mx-auto space-y-4">
@@ -387,6 +424,101 @@ export default function ParentDashboard() {
                     <p className="mt-1.5 ml-5 text-muted text-xs italic">
                       Feedback: {assignment.feedback}
                     </p>
+                  )}
+                </div>
+              );
+            })}
+
+            {pendingBountyClaims.map((claim) => {
+              const verifyKey = `bounty-verify-${claim.id}`;
+              const rejectKey = `bounty-reject-${claim.id}`;
+              const isVerifying = actionLoading[verifyKey];
+              const isRejecting = actionLoading[rejectKey];
+              const isBusy = isVerifying || isRejecting;
+              const claimDate = utcToLocalDateISO(claim.completed_at);
+              const isToday = claimDate === todayLocalISO();
+
+              return (
+                <div
+                  key={`bounty-${claim.id}`}
+                  className="game-panel p-3"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <p
+                          className="text-cream text-sm font-medium truncate cursor-pointer hover:text-accent transition-colors"
+                          onClick={() => navigate(`/bounty`)}
+                        >
+                          {themedTitle(claim.chore_title || 'Bounty', colorTheme)}
+                        </p>
+                        <span className="inline-flex items-center gap-1 text-purple-400 text-xs font-medium flex-shrink-0">
+                          <Swords size={10} /> Bounty
+                        </span>
+                      </div>
+                      <p className="text-muted text-xs mt-0.5">
+                        by {claim.user_display_name || 'Kid'}
+                        {claim.chore_requires_photo && (
+                          <span className="inline-flex items-center gap-1 ml-2 text-accent">
+                            <Camera size={10} /> Photo
+                          </span>
+                        )}
+                        {claim.chore_points != null && (
+                          <span className="ml-2 text-gold font-medium">+{claim.chore_points} XP</span>
+                        )}
+                      </p>
+                      {claimDate && (
+                        <p className="flex items-center gap-1 text-xs mt-1">
+                          <CalendarDays size={11} className={isToday ? 'text-accent' : 'text-orange-400'} />
+                          <span className={isToday ? 'text-accent font-medium' : 'text-orange-400 font-medium'}>
+                            {getDateLabel(claimDate)}
+                          </span>
+                          {claim.completed_at && (
+                            <span className="text-muted ml-1">
+                              · submitted {new Date(/Z|[+-]\d\d:?\d\d$/.test(claim.completed_at) ? claim.completed_at : claim.completed_at + 'Z').toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
+                            </span>
+                          )}
+                        </p>
+                      )}
+                      {claim.kid_note && (
+                        <p className="mt-1 text-muted text-xs italic">"{claim.kid_note}"</p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1.5 flex-shrink-0">
+                      <button
+                        className="game-btn game-btn-blue !px-2.5 !py-1.5"
+                        disabled={isBusy}
+                        onClick={() => handleVerifyBounty(claim.id)}
+                        title="Approve"
+                      >
+                        {isVerifying ? (
+                          <Loader2 size={14} className="animate-spin" />
+                        ) : (
+                          <CheckCircle2 size={14} />
+                        )}
+                      </button>
+                      <button
+                        className="game-btn game-btn-red !px-2.5 !py-1.5"
+                        disabled={isBusy}
+                        onClick={() => handleRejectBounty(claim.id)}
+                        title="Reject"
+                      >
+                        {isRejecting ? (
+                          <Loader2 size={14} className="animate-spin" />
+                        ) : (
+                          <XCircle size={14} />
+                        )}
+                      </button>
+                    </div>
+                  </div>
+                  {claim.photo_proof_path && (
+                    <div className="mt-2">
+                      <img
+                        src={`/api/uploads/${claim.photo_proof_path}`}
+                        alt="Photo proof"
+                        className="rounded-md max-h-48 object-cover border border-border"
+                      />
+                    </div>
                   )}
                 </div>
               );

--- a/tests/e2e/parent-dashboard.spec.js
+++ b/tests/e2e/parent-dashboard.spec.js
@@ -205,6 +205,129 @@ test.describe('Parent — party and kid detail', () => {
   });
 });
 
+// ─── Bounty claim approvals on home screen ───────────────────────────────────
+
+/** Create a bounty, have the kid claim and complete it, return the claim. */
+async function createAndCompleteBountyClaim(parentToken, kidToken) {
+  const cats = await apiGet('/api/chores/categories', parentToken);
+  const categoryId = cats[0]?.id;
+
+  const res = await fetch(`${BASE}/api/chores`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${parentToken}` },
+    body: JSON.stringify({
+      title: `Dashboard Bounty ${Date.now()}`,
+      points: 25,
+      difficulty: 'easy',
+      recurrence: 'once',
+      category_id: categoryId,
+    }),
+  });
+  const chore = await res.json();
+
+  // Mark as bounty
+  await fetch(`${BASE}/api/chores/${chore.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${parentToken}` },
+    body: JSON.stringify({ is_bounty: true }),
+  });
+
+  // Kid claims then completes
+  await apiPost(`/api/bounty/${chore.id}/claim`, kidToken);
+  const fd = new FormData();
+  await fetch(`${BASE}/api/bounty/${chore.id}/complete`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${kidToken}` },
+    body: fd,
+  });
+
+  const claims = await apiGet('/api/bounty/claims', parentToken);
+  return claims.find((c) => c.chore_id === chore.id);
+}
+
+test.describe('Parent Dashboard — bounty claim approvals', () => {
+  test('completed bounty claim appears in Pending Verifications with Bounty badge', async ({ loginAsParent: page }) => {
+    const { parentToken, kidToken } = loadTokens();
+    await createAndCompleteBountyClaim(parentToken, kidToken);
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('text=Pending Verifications')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('text=Bounty').first()).toBeVisible({ timeout: 8_000 });
+  });
+
+  test('bounty claim card shows a date label (Today or Yesterday)', async ({ loginAsParent: page }) => {
+    const { parentToken, kidToken } = loadTokens();
+    await createAndCompleteBountyClaim(parentToken, kidToken);
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    await expect(
+      page.locator('text=/Today|Yesterday/i').first()
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  test('approving a bounty claim from home screen removes it from the queue (API)', async () => {
+    const { parentToken, kidToken, kidId } = loadTokens();
+    const claim = await createAndCompleteBountyClaim(parentToken, kidToken);
+    expect(claim, 'Claim not found in pending queue').toBeTruthy();
+
+    const before = await apiGet(`/api/points/${kidId}`, parentToken);
+
+    const verify = await apiPost(`/api/bounty/claims/${claim.id}/verify`, parentToken);
+    expect(verify.status, `verify failed: ${JSON.stringify(verify.body)}`).toBe(200);
+
+    // Claim no longer in pending queue
+    const pending = await apiGet('/api/bounty/claims', parentToken);
+    expect(pending.find((c) => c.id === claim.id)).toBeFalsy();
+
+    // XP awarded
+    const after = await apiGet(`/api/points/${kidId}`, parentToken);
+    expect(after.balance).toBeGreaterThan(before.balance);
+  });
+
+  test('approving a bounty claim via UI removes it from the pending list', async ({ loginAsParent: page }) => {
+    const { parentToken, kidToken } = loadTokens();
+    await createAndCompleteBountyClaim(parentToken, kidToken);
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    // Wait for at least one approve button to appear
+    const approveBtn = page.locator('[title="Approve"]').first();
+    if (!(await approveBtn.isVisible({ timeout: 8_000 }).catch(() => false))) return;
+
+    const countBefore = await page.locator('[title="Approve"]').count();
+    await approveBtn.click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('text=/error/i')).not.toBeVisible({ timeout: 3_000 }).catch(() => {});
+    const countAfter = await page.locator('[title="Approve"]').count();
+    expect(countAfter).toBeLessThan(countBefore);
+  });
+
+  test('rejecting a bounty claim via UI removes it from the pending list', async ({ loginAsParent: page }) => {
+    const { parentToken, kidToken } = loadTokens();
+    await createAndCompleteBountyClaim(parentToken, kidToken);
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    const rejectBtn = page.locator('[title="Reject"]').first();
+    if (!(await rejectBtn.isVisible({ timeout: 8_000 }).catch(() => false))) return;
+
+    const countBefore = await page.locator('[title="Reject"]').count();
+    await rejectBtn.click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('text=/error/i')).not.toBeVisible({ timeout: 3_000 }).catch(() => {});
+    const countAfter = await page.locator('[title="Reject"]').count();
+    expect(countAfter).toBeLessThan(countBefore);
+  });
+});
+
 // ─── Shoutouts ────────────────────────────────────────────────────────────────
 
 test.describe('Parent — shoutouts', () => {

--- a/tests/e2e/parent-dashboard.spec.js
+++ b/tests/e2e/parent-dashboard.spec.js
@@ -212,7 +212,7 @@ async function createAndCompleteBountyClaim(parentToken, kidToken) {
   const cats = await apiGet('/api/chores/categories', parentToken);
   const categoryId = cats[0]?.id;
 
-  const res = await fetch(`${BASE}/api/chores`, {
+  const choreRes = await fetch(`${BASE}/api/chores`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${parentToken}` },
     body: JSON.stringify({
@@ -223,23 +223,28 @@ async function createAndCompleteBountyClaim(parentToken, kidToken) {
       category_id: categoryId,
     }),
   });
-  const chore = await res.json();
+  if (!choreRes.ok) throw new Error(`Create chore failed ${choreRes.status}: ${await choreRes.text()}`);
+  const chore = await choreRes.json();
 
   // Mark as bounty
-  await fetch(`${BASE}/api/chores/${chore.id}`, {
+  const bountyRes = await fetch(`${BASE}/api/chores/${chore.id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${parentToken}` },
     body: JSON.stringify({ is_bounty: true }),
   });
+  if (!bountyRes.ok) throw new Error(`Set is_bounty failed ${bountyRes.status}: ${await bountyRes.text()}`);
 
   // Kid claims then completes
-  await apiPost(`/api/bounty/${chore.id}/claim`, kidToken);
+  const claimResult = await apiPost(`/api/bounty/${chore.id}/claim`, kidToken);
+  if (claimResult.status >= 300) throw new Error(`Claim failed ${claimResult.status}: ${JSON.stringify(claimResult.body)}`);
+
   const fd = new FormData();
-  await fetch(`${BASE}/api/bounty/${chore.id}/complete`, {
+  const completeRes = await fetch(`${BASE}/api/bounty/${chore.id}/complete`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${kidToken}` },
     body: fd,
   });
+  if (!completeRes.ok) throw new Error(`Complete failed ${completeRes.status}: ${await completeRes.text()}`);
 
   const claims = await apiGet('/api/bounty/claims', parentToken);
   return claims.find((c) => c.chore_id === chore.id);
@@ -295,9 +300,8 @@ test.describe('Parent Dashboard — bounty claim approvals', () => {
     await page.reload();
     await page.waitForLoadState('networkidle');
 
-    // Wait for at least one approve button to appear
     const approveBtn = page.locator('[title="Approve"]').first();
-    if (!(await approveBtn.isVisible({ timeout: 8_000 }).catch(() => false))) return;
+    await expect(approveBtn).toBeVisible({ timeout: 10_000 });
 
     const countBefore = await page.locator('[title="Approve"]').count();
     await approveBtn.click();
@@ -316,7 +320,7 @@ test.describe('Parent Dashboard — bounty claim approvals', () => {
     await page.waitForLoadState('networkidle');
 
     const rejectBtn = page.locator('[title="Reject"]').first();
-    if (!(await rejectBtn.isVisible({ timeout: 8_000 }).catch(() => false))) return;
+    await expect(rejectBtn).toBeVisible({ timeout: 10_000 });
 
     const countBefore = await page.locator('[title="Reject"]').count();
     await rejectBtn.click();

--- a/tests/e2e/parent-dashboard.spec.js
+++ b/tests/e2e/parent-dashboard.spec.js
@@ -247,7 +247,9 @@ async function createAndCompleteBountyClaim(parentToken, kidToken) {
   if (!completeRes.ok) throw new Error(`Complete failed ${completeRes.status}: ${await completeRes.text()}`);
 
   const claims = await apiGet('/api/bounty/claims', parentToken);
-  return claims.find((c) => c.chore_id === chore.id);
+  const claim = claims.find((c) => c.chore_id === chore.id);
+  if (!claim) throw new Error(`Claim for chore ${chore.id} not found in pending queue. Queue: ${JSON.stringify(claims.map((c) => c.chore_id))}`);
+  return claim;
 }
 
 test.describe('Parent Dashboard — bounty claim approvals', () => {

--- a/tests/e2e/parent-dashboard.spec.js
+++ b/tests/e2e/parent-dashboard.spec.js
@@ -302,8 +302,12 @@ test.describe('Parent Dashboard — bounty claim approvals', () => {
     await page.reload();
     await page.waitForLoadState('networkidle');
 
-    const approveBtn = page.locator('[title="Approve"]').first();
-    await expect(approveBtn).toBeVisible({ timeout: 10_000 });
+    // Scope to the bounty card specifically so we don't accidentally click a
+    // regular chore approval button if any are also in the queue.
+    const bountyCard = page.locator('.game-panel', { has: page.locator('text=Bounty') }).first();
+    await expect(bountyCard).toBeVisible({ timeout: 10_000 });
+    const approveBtn = bountyCard.locator('[title="Approve"]');
+    await expect(approveBtn).toBeVisible();
 
     const countBefore = await page.locator('[title="Approve"]').count();
     await approveBtn.click();
@@ -321,8 +325,10 @@ test.describe('Parent Dashboard — bounty claim approvals', () => {
     await page.reload();
     await page.waitForLoadState('networkidle');
 
-    const rejectBtn = page.locator('[title="Reject"]').first();
-    await expect(rejectBtn).toBeVisible({ timeout: 10_000 });
+    const bountyCard = page.locator('.game-panel', { has: page.locator('text=Bounty') }).first();
+    await expect(bountyCard).toBeVisible({ timeout: 10_000 });
+    const rejectBtn = bountyCard.locator('[title="Reject"]');
+    await expect(rejectBtn).toBeVisible();
 
     const countBefore = await page.locator('[title="Reject"]').count();
     await rejectBtn.click();


### PR DESCRIPTION
## Summary
- A phone (or any device) opening ChoreQuest fresh while an update was in progress would bypass the update screen entirely — the WS broadcast had already fired before they connected, and with no version baseline they had nothing to compare against
- The health endpoint (`/api/health`) now returns `updating: true` / `status: "updating"` when the watchdog lock file (`/app/data/.update_in_progress`) exists on disk
- The overlay's initial mount health check (which already ran on load) now acts on that flag immediately, showing the overlay for fresh visitors mid-update
- No new polling — piggybacks on the check that was already happening at mount

## Why this is safe (no spurious overlays)
- The lock file only exists while `watchdog.sh` is actively running a deploy — it's written at deploy start and deleted when deploy completes
- New containers start without the lock file, so the health endpoint returns `ok` as soon as the new container is healthy
- The existing transient-network-error guard (PR #83) is unaffected

## Previous attempts this builds on
- PR fixing race condition + backgrounded tab detection (`5150a50`)
- PR #83 fixing spurious overlays from transient network errors

## Test plan
- [ ] Trigger an update, then open ChoreQuest on a second device that wasn't connected — confirm the update overlay appears immediately
- [ ] Confirm a normal page load (no update in progress) shows no overlay
- [ ] Confirm the overlay dismisses and reloads normally once the new container is up

🤖 Generated with [Claude Code](https://claude.com/claude-code)