### PR TITLE
Fix skip_chore missing kid_id param and grace_period_days crash

### DIFF
--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -866,7 +866,10 @@ async def complete_chore(
         select(AppSetting).where(AppSetting.key == "grace_period_days")
     )
     grace_setting = grace_result.scalar_one_or_none()
-    grace_days = int(grace_setting.value) if grace_setting else 1
+    try:
+        grace_days = int(grace_setting.value) if grace_setting else 1
+    except ValueError:
+        grace_days = 1
     earliest = today - timedelta(days=grace_days)
 
     # Guard: prevent completing today's assignment twice — prevents double XP.
@@ -1421,19 +1424,22 @@ async def uncomplete_chore(
 @router.post("/{chore_id}/skip", response_model=AssignmentResponse)
 async def skip_chore(
     chore_id: int,
+    kid_id: int | None = Query(None),
     db: AsyncSession = Depends(get_db),
     user: User = Depends(require_parent),
 ):
     today = date.today()
     now = datetime.now(timezone.utc)
 
-    result = await db.execute(
-        select(ChoreAssignment).where(
-            ChoreAssignment.chore_id == chore_id,
-            ChoreAssignment.date == today,
-            ChoreAssignment.status == AssignmentStatus.pending,
-        )
-    )
+    filters = [
+        ChoreAssignment.chore_id == chore_id,
+        ChoreAssignment.date == today,
+        ChoreAssignment.status == AssignmentStatus.pending,
+    ]
+    if kid_id is not None:
+        filters.append(ChoreAssignment.user_id == kid_id)
+
+    result = await db.execute(select(ChoreAssignment).where(*filters))
     assignment = result.scalar_one_or_none()
     if assignment is None:
         raise HTTPException(


### PR DESCRIPTION
## Summary

- **#108**: `skip_chore` now accepts an optional `kid_id` query param, matching the existing pattern in `uncomplete_chore`. Without it, if two kids share the same chore and both have a pending assignment today, the endpoint would skip whichever the DB returned first with no way to specify which kid.
- **#109**: `int(grace_setting.value)` is now wrapped in `try/except ValueError` to fall back to `1` day instead of returning a 500 if the `grace_period_days` AppSetting is misconfigured with a non-numeric value.

Closes #108, #109

## Test plan

- [ ] All 97 unit tests pass (`python3 -m pytest tests/unit/ -q`)
- [ ] CI green (backend, lint, E2E)
- [ ] Manual: verify `POST /{chore_id}/skip?kid_id=X` correctly targets the specified kid's assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)