### PR TITLE
Fix spin wheel: 3-day lookback window, rename credit → spin

### DIFF
--- a/backend/routers/spin.py
+++ b/backend/routers/spin.py
@@ -1,5 +1,5 @@
 import random
-from datetime import date
+from datetime import date, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.exc import IntegrityError
@@ -52,6 +52,7 @@ async def _can_spin_today(
              available_credit_count, available_credit_dates).
     """
     today = date.today()
+    lookback_start = today - timedelta(days=3)
 
     # Get last spin result for display
     last_result: int | None = None
@@ -81,13 +82,15 @@ async def _can_spin_today(
         else (AssignmentStatus.completed, AssignmentStatus.verified, AssignmentStatus.skipped)
     )
 
-    # Load all assignments up through today. Fully-satisfied dates become spin credits.
-    # This intentionally has no lookback cutoff because spin credits do not expire.
-    # Query cost is controlled by idx_chore_assignments_user_date.
+    # Load assignments from the last 3 days through today.
+    # Fully-satisfied dates become available spins.
+    # A short lookback window prevents historical backlog from accumulating
+    # unlimited spins while still allowing late parent approvals to count.
     result = await db.execute(
         select(ChoreAssignment.date, ChoreAssignment.status)
         .where(
             ChoreAssignment.user_id == user.id,
+            ChoreAssignment.date >= lookback_start,
             ChoreAssignment.date <= today,
         )
         .order_by(ChoreAssignment.date.asc())
@@ -129,7 +132,7 @@ async def _can_spin_today(
         return (
             False,
             last_result,
-            f"You already used all available spin credits. {earn_more_hint}",
+            f"You already used all available spins. {earn_more_hint}",
             0,
             [],
         )
@@ -161,14 +164,14 @@ async def _can_spin_today(
         return (
             False,
             last_result,
-            f"Complete all of today's quests to unlock a spin credit! {pending} remaining.",
+            f"Complete all of today's quests to unlock a spin! {pending} remaining.",
             0,
             [],
         )
     no_credit_msg = (
-        "No spin credits yet. Complete and verify quests to earn one."
+        "No spins yet. Complete and verify quests to earn one."
         if requires_verification
-        else "No spin credits yet. Complete quests to earn one."
+        else "No spins yet. Complete quests to earn one."
     )
     return (False, last_result, no_credit_msg, 0, [])
 
@@ -240,7 +243,7 @@ async def execute_spin(
         await db.commit()
     except IntegrityError:
         await db.rollback()
-        raise HTTPException(status_code=409, detail="Spin already recorded for this credit. Please try again.")
+        raise HTTPException(status_code=409, detail="Spin already recorded. Please try again.")
     await db.refresh(spin_result)
 
     # Check achievements (non-blocking on failure)

--- a/frontend/src/components/SpinWheel.jsx
+++ b/frontend/src/components/SpinWheel.jsx
@@ -194,17 +194,17 @@ export default function SpinWheel({ availability, onSpinComplete }) {
         <p className="text-gold text-sm text-center max-w-xs">{reason}</p>
       )}
 
-      {/* After a spin: prompt if more credits remain */}
+      {/* After a spin: prompt if more spins remain */}
       {result !== null && canSpin && !spinning && (
         <p className="text-accent text-sm text-center font-medium">
-          You have {spinCredits} credit{spinCredits === 1 ? '' : 's'} left — spin again!
+          You have {spinCredits} spin{spinCredits === 1 ? '' : 's'} left — spin again!
         </p>
       )}
 
-      {/* Before spinning: show credit count when more than 1 available */}
+      {/* Before spinning: show spin count when more than 1 available */}
       {result === null && spinCredits > 1 && (
         <p className="text-muted text-xs text-center">
-          {spinCredits} spin credits ready
+          {spinCredits} spins ready
         </p>
       )}
 

--- a/tests/unit/test_spin_credits.py
+++ b/tests/unit/test_spin_credits.py
@@ -111,6 +111,29 @@ async def test_no_credit_when_today_still_pending(db):
 
 
 @pytest.mark.asyncio
+async def test_assignment_older_than_lookback_does_not_grant_spin(db):
+    today = date.today()
+    before_lookback = today - timedelta(days=4)
+
+    category = await make_category(db)
+    parent = await make_user(db, "spin_parent_lookback", role=UserRole.parent)
+    kid = await make_user(db, "spin_kid_lookback")
+    chore = await make_chore(db, parent.id, category.id)
+
+    await _add_assignment(db, chore.id, kid.id, before_lookback, AssignmentStatus.verified)
+    await _add_assignment(db, chore.id, kid.id, today, AssignmentStatus.pending)
+    await db.commit()
+
+    can_spin, _, reason, spin_credits, credit_dates = await _can_spin_today(db, kid)
+
+    assert can_spin is False
+    assert spin_credits == 0
+    assert credit_dates == []
+    assert reason is not None
+    assert "unlock a spin" in reason
+
+
+@pytest.mark.asyncio
 async def test_no_credit_message_omits_verify_when_verification_disabled(db):
     """When spin_requires_verification=false, the no-credits message should not
     mention 'verify' since kids don't need parent approval to earn credits."""

--- a/tests/unit/test_spin_credits.py
+++ b/tests/unit/test_spin_credits.py
@@ -107,7 +107,7 @@ async def test_no_credit_when_today_still_pending(db):
     assert spin_credits == 0
     assert credit_dates == []
     assert reason is not None
-    assert "unlock a spin credit" in reason
+    assert "unlock a spin" in reason
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `_can_spin_today()` previously loaded **all** chore assignments from the beginning of time to compute available spins. On a family instance with months of history, upgrading to the spin feature would instantly queue hundreds of credits — kids could spin indefinitely until the backlog was exhausted.
- Fix: add `lookback_start = today - timedelta(days=3)` and filter the assignments query to `date >= lookback_start`. Three days is wide enough to cover late parent approvals (the carryover feature from #90) while capping the historical backlog problem.
- Renames all user-facing "credit(s)" → "spin(s)" to match existing UI terminology.
- Updates the one unit test assertion that checked for the old "unlock a spin credit" wording.

## Attribution

Ported from [adrianba/ChoreQuest@4fdb06f](https://github.com/adrianba/ChoreQuest/commit/4fdb06fd6addf91842a7ece35d85ad3f2f3b1e0d) by [Ade Bateman](https://github.com/adrianba). Thanks Ade!

## Test plan
- [ ] All 4 existing spin unit tests pass (`tests/unit/test_spin_credits.py`)
- [ ] Spin wheel still works for a kid with quests completed in the last 3 days
- [ ] Old spin history (used credits) is unaffected — already-spent spin dates are still in `spin_results`
- [ ] UI shows "1 spin left" / "2 spins ready" (not "credits")

🤖 Generated with [Claude Code](https://claude.com/claude-code)