### PR TITLE
fix(rotation): preserve current_index when re-saving rotation without changing kids

### DIFF
--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -541,10 +541,17 @@ async def assign_chore(
         kid_ids = [a.user_id for a in body.assignments]
         inverse_chore_id = getattr(body.rotation, "inverse_of_chore_id", None)
         if existing_rotation:
+            # Only reset the rotation clock when the kid list actually changes.
+            # Re-saving without changing kids (e.g. editing cadence or photo
+            # settings) should not clobber current_index or last_rotated —
+            # doing so would cause the daily reset to skip the next natural
+            # advance, giving the wrong kid an extra cycle.
+            kids_changed = [int(k) for k in (existing_rotation.kid_ids or [])] != [int(k) for k in kid_ids]
             existing_rotation.kid_ids = kid_ids
             existing_rotation.cadence = body.rotation.cadence
-            existing_rotation.current_index = 0
-            existing_rotation.last_rotated = datetime.now(timezone.utc)
+            if kids_changed:
+                existing_rotation.current_index = 0
+                existing_rotation.last_rotated = datetime.now(timezone.utc)
             existing_rotation.inverse_of_chore_id = inverse_chore_id
         else:
             existing_rotation = ChoreRotation(


### PR DESCRIPTION
## Problem

Re-saving a chore's assignment settings (e.g. changing cadence from weekly→daily, or toggling photo requirements) while keeping the **same kid list** was unconditionally resetting `current_index = 0` and `last_rotated = now()` in the `assign_chore` endpoint.

This caused the daily reset logic to treat the next cycle as if the rotation had just started, giving the same kid an extra cycle instead of advancing normally to the next kid.

## Fix

Only reset `current_index` and `last_rotated` when `kid_ids` actually changes — a genuine reassignment that should restart the rotation order. When only cadence, photo requirements, or other settings change, the rotation clock is left untouched.

## Testing

- Open a chore with an active rotation
- Change the cadence (e.g. Daily → Weekly) and save — `current_index` should remain unchanged
- Remove a kid and re-add them — `current_index` should reset to 0 as expected