### PR TITLE
fix(rotation): show today's actual assigned kid, not post-reset next-day kid

### DIFF
--- a/backend/routers/_chores_helpers.py
+++ b/backend/routers/_chores_helpers.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from backend.models import (
+    AssignmentStatus,
     Chore,
     ChoreAssignment,
     ChoreRotation,
@@ -111,6 +112,28 @@ async def build_rotation_summaries(
     today = date.today()
     now = datetime.now(timezone.utc)
 
+    # Batch-load today's actual assignments for all rotation chores so we can
+    # ground the "currently X's turn" display in what was really scheduled for
+    # today rather than blindly trusting current_index.
+    #
+    # This matters when the daily reset fires before local midnight (e.g. UTC
+    # midnight = 7 pm CDT): current_index is already advanced to tomorrow's
+    # kid, but today's local assignment still belongs to the previous kid.
+    all_chore_ids = [r.chore_id for r in rotations]
+    today_assignment_result = await db.execute(
+        select(ChoreAssignment.chore_id, ChoreAssignment.user_id)
+        .where(
+            ChoreAssignment.chore_id.in_(all_chore_ids),
+            ChoreAssignment.user_id.in_(all_kid_ids),
+            ChoreAssignment.date == today,
+            ChoreAssignment.status != AssignmentStatus.skipped,
+        )
+    )
+    # chore_id → kid_id who has today's actual assignment (non-skipped)
+    today_assigned_kid: dict[int, int] = {
+        row.chore_id: row.user_id for row in today_assignment_result.all()
+    }
+
     summaries: dict[int, RotationSummary] = {}
     for r in rotations:
         kid_ids = r.kid_ids or []
@@ -136,6 +159,16 @@ async def build_rotation_summaries(
         else:
             idx = r.current_index % len(kid_ids)
             current_kid_id = kid_ids[idx]
+
+        # Ground-truth override: if there is an actual non-skipped assignment
+        # for today belonging to one of this rotation's kids, that kid is who
+        # the family will see doing the chore today — show them as "current".
+        # This prevents the display from jumping to tomorrow's kid after the
+        # UTC-midnight reset fires before local midnight.
+        actual_today_kid = today_assigned_kid.get(r.chore_id)
+        if actual_today_kid is not None and actual_today_kid in kid_ids:
+            current_kid_id = actual_today_kid
+            idx = kid_ids.index(current_kid_id)
 
         summaries[r.chore_id] = RotationSummary(
             current_kid_id=current_kid_id,

--- a/backend/routers/_chores_helpers.py
+++ b/backend/routers/_chores_helpers.py
@@ -10,7 +10,7 @@ These are internal utilities used across the chores router endpoints:
 from datetime import date, datetime, timezone
 
 from fastapi import HTTPException
-from sqlalchemy import select
+from sqlalchemy import case, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -120,6 +120,15 @@ async def build_rotation_summaries(
     # midnight = 7 pm CDT): current_index is already advanced to tomorrow's
     # kid, but today's local assignment still belongs to the previous kid.
     all_chore_ids = [r.chore_id for r in rotations]
+    # Order so that the most "active" row wins when multiple non-skipped
+    # assignments exist for the same chore/date (e.g. a stale verified row
+    # left over from a previous rotation cycle alongside a new pending one).
+    # pending=0 < completed=1 < verified=2, then newest id first as tiebreak.
+    _status_priority = case(
+        (ChoreAssignment.status == AssignmentStatus.pending, 0),
+        (ChoreAssignment.status == AssignmentStatus.completed, 1),
+        else_=2,
+    )
     today_assignment_result = await db.execute(
         select(ChoreAssignment.chore_id, ChoreAssignment.user_id)
         .where(
@@ -128,11 +137,13 @@ async def build_rotation_summaries(
             ChoreAssignment.date == today,
             ChoreAssignment.status != AssignmentStatus.skipped,
         )
+        .order_by(_status_priority, ChoreAssignment.id.desc())
     )
-    # chore_id → kid_id who has today's actual assignment (non-skipped)
-    today_assigned_kid: dict[int, int] = {
-        row.chore_id: row.user_id for row in today_assignment_result.all()
-    }
+    # chore_id → kid_id who has today's most-active assignment.
+    # setdefault keeps only the first (highest-priority) row per chore.
+    today_assigned_kid: dict[int, int] = {}
+    for row in today_assignment_result.all():
+        today_assigned_kid.setdefault(row.chore_id, row.user_id)
 
     summaries: dict[int, RotationSummary] = {}
     for r in rotations:

--- a/frontend/src/pages/ChoreDetail.jsx
+++ b/frontend/src/pages/ChoreDetail.jsx
@@ -676,7 +676,11 @@ export default function ChoreDetail() {
                 Rotation active — currently{' '}
                 <span className="font-semibold text-purple">
                   {(() => {
-                    const currentKidId = rotation.kid_ids?.[rotation.current_index];
+                    // Prefer rotation_summary (grounded in today's actual
+                    // assignment) over raw current_index from /api/rotations,
+                    // which advances to tomorrow's kid before local midnight.
+                    const currentKidId = chore.rotation_summary?.current_kid_id
+                      ?? rotation.kid_ids?.[rotation.current_index];
                     const currentKid = allKids.find((k) => k.id === currentKidId);
                     return currentKid?.display_name || `Kid #${currentKidId}`;
                   })()}
@@ -767,7 +771,12 @@ export default function ChoreDetail() {
               <div className="flex flex-wrap gap-2">
                 {(rotation.kid_ids || []).map((kidId, idx) => {
                   const kid = allKids.find((k) => k.id === kidId);
-                  const isCurrent = idx === rotation.current_index;
+                  // Prefer rotation_summary.current_kid_id (grounded in today's
+                  // actual assignment) over raw current_index, which advances
+                  // to tomorrow's kid before local midnight after the UTC reset.
+                  const isCurrent = chore.rotation_summary
+                    ? kidId === chore.rotation_summary.current_kid_id
+                    : idx === rotation.current_index;
                   return (
                     <span
                       key={kidId}

--- a/tests/unit/test_rotation_summary.py
+++ b/tests/unit/test_rotation_summary.py
@@ -15,7 +15,7 @@ from datetime import date, datetime, timedelta, timezone
 from tests.unit.conftest import (
     make_category, make_chore, make_user, make_rotation,
 )
-from backend.models import RotationCadence
+from backend.models import AssignmentStatus, ChoreAssignment, RotationCadence
 from backend.routers._chores_helpers import build_rotation_summaries
 from backend.services.rotation import get_rotation_kid_for_day
 
@@ -159,3 +159,102 @@ async def test_summary_daily_cadence_advance_pending(db):
     summaries = await build_rotation_summaries(db, [chore.id])
     assert chore.id in summaries
     assert summaries[chore.id].current_kid_id == projected_kid_id
+
+
+@pytest.mark.asyncio
+async def test_summary_uses_todays_assignment_after_utc_reset(db):
+    """
+    Regression: after the UTC-midnight reset fires before local midnight,
+    current_index already points to tomorrow's kid while today's assignment
+    still belongs to the previous kid.
+
+    Scenario (e.g. 8 pm CDT = UTC midnight)
+    ----------------------------------------
+    Daily rotation [Kid1, Kid2].
+    UTC reset has already fired: current_index=1 → Kid2, last_rotated=today.
+    But today's ChoreAssignment (date=today) was created for Kid1 — it is
+    still pending and visible on the quest board.
+
+    build_rotation_summaries() must return Kid1, not Kid2.
+    """
+    from backend.models import UserRole
+    cat = await make_category(db)
+    parent = await make_user(db, "parent_tz", role=UserRole.parent)
+    kid1 = await make_user(db, "kid_tz_1")
+    kid2 = await make_user(db, "kid_tz_2")
+    chore = await make_chore(db, parent.id, cat.id)
+
+    today = date.today()
+    # Simulate: UTC reset already ran and advanced index to 1 (Kid2)
+    last_rotated = datetime.combine(today, datetime.min.time()).replace(tzinfo=timezone.utc)
+    await make_rotation(
+        db,
+        chore.id,
+        kid_ids=[kid1.id, kid2.id],
+        cadence=RotationCadence.daily,
+        current_index=1,           # post-reset: points to Kid2 (tomorrow)
+        last_rotated=last_rotated,
+    )
+
+    # Today's assignment was created for Kid1 (before the reset or by the
+    # previous reset cycle) and is still pending on the quest board.
+    assignment = ChoreAssignment(
+        chore_id=chore.id,
+        user_id=kid1.id,
+        date=today,
+        status=AssignmentStatus.pending,
+    )
+    db.add(assignment)
+    await db.flush()
+
+    summaries = await build_rotation_summaries(db, [chore.id])
+    assert chore.id in summaries
+    assert summaries[chore.id].current_kid_id == kid1.id, (
+        "Should show Kid1 (today's actual assignment) not Kid2 "
+        "(post-UTC-reset current_index pointing to tomorrow)"
+    )
+    assert summaries[chore.id].current_index == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_prefers_pending_over_stale_verified_when_both_exist(db):
+    """
+    Dict-collision guard: if a chore/date has both a stale verified row
+    (from a previous rotation cycle that happened to fall on the same date)
+    and a current pending row, the pending kid should win.
+    """
+    from backend.models import UserRole
+    cat = await make_category(db)
+    parent = await make_user(db, "parent_col", role=UserRole.parent)
+    kid1 = await make_user(db, "kid_col_1")
+    kid2 = await make_user(db, "kid_col_2")
+    chore = await make_chore(db, parent.id, cat.id)
+
+    today = date.today()
+    last_rotated = datetime.combine(today, datetime.min.time()).replace(tzinfo=timezone.utc)
+    await make_rotation(
+        db,
+        chore.id,
+        kid_ids=[kid1.id, kid2.id],
+        cadence=RotationCadence.daily,
+        current_index=0,
+        last_rotated=last_rotated,
+    )
+
+    # Stale verified assignment (from a previous rotation pass, same date)
+    db.add(ChoreAssignment(
+        chore_id=chore.id, user_id=kid2.id,
+        date=today, status=AssignmentStatus.verified,
+    ))
+    # Current pending assignment — this is the real one for today
+    db.add(ChoreAssignment(
+        chore_id=chore.id, user_id=kid1.id,
+        date=today, status=AssignmentStatus.pending,
+    ))
+    await db.flush()
+
+    summaries = await build_rotation_summaries(db, [chore.id])
+    assert chore.id in summaries
+    assert summaries[chore.id].current_kid_id == kid1.id, (
+        "Pending assignment should win over stale verified row for same date"
+    )


### PR DESCRIPTION
## Problem

The \"Rotation active — currently X's turn\" banner and the `(current)` badge in the Kid Rotation panel were showing the **wrong kid** after the UTC-midnight daily reset fires — which is **before** local midnight in negative-UTC-offset timezones.

For example, with `TZ=America/Chicago` (UTC-5/CDT), the daily reset fires at **7 pm local time**. After that point:

- `current_index` is already advanced to **tomorrow's** kid (the UTC-date assignment)
- But **today's local date** still has the *previous* kid's assignment pending in the quest board

Result (observed on live server): The Recycling March rotation showed **\"Kai (current)\"** in the detail panel, but Finn's quest card was the one actually pending for the day.

## Root cause

`build_rotation_summaries` in `_chores_helpers.py` had two code paths:
1. `should_advance_rotation() == True` → project forward (reset hasn't fired yet) ✅
2. `should_advance_rotation() == False` → trust `current_index` directly ❌

Path 2 is wrong after the reset fires pre-local-midnight: `current_index` already points to the UTC-tomorrow kid.

## Fix

After computing the initial `current_kid_id` via the existing projection logic, batch-query for any non-skipped `ChoreAssignment` dated **today** for this chore's rotation kids. If one exists, it is the ground truth for who is actually doing the chore today, and overrides `current_index` for display purposes.

This is **display-only** — the rotation model (`current_index`, `last_rotated`) is not modified.

## Testing

- Observed live on `http://chorequest:8122` via the debug endpoint: `last_rotated = 2026-05-19T00:00:00 UTC` (= 7pm CDT May 18), `current_index = 0` (Kai), but today's assignment `date=2026-05-18` is for Finn (user_id=4).
- After this fix, the rotation panel will show Finn as current until midnight local time.