### PR TITLE
fix(scheduler): run daily reset at local midnight, not UTC midnight

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ When triggered, `watchdog.sh` runs `deploy.sh` which does `git pull` + `docker c
 | `COOKIE_SECURE` | `false` | Set `true` behind HTTPS |
 | `CORS_ORIGINS` | *(empty)* | Comma-separated allowed origins |
 | `MAX_UPLOAD_SIZE_MB` | `5` | Photo proof upload size limit |
-| `DAILY_RESET_HOUR` | `0` | Hour (UTC) the daily quest reset runs |
+| `DAILY_RESET_HOUR` | `0` | Hour (local time, respects `TZ`) the daily quest reset runs |
 | `GITHUB_REPO` | `turbogizzmo/ChoreQuest` | Repo used for in-app update checks |
 | `VAPID_PUBLIC_KEY` | *(empty)* | VAPID public key for push notifications |
 | `VAPID_PRIVATE_KEY` | *(empty)* | VAPID private key for push notifications |

--- a/backend/main.py
+++ b/backend/main.py
@@ -86,14 +86,21 @@ async def daily_reset_task():
     Responsibilities:
     - Generate today's recurring chore assignments (with rotation advancement)
     - Clean up expired refresh tokens
+
+    IMPORTANT: next-run time is computed in **local** time (respecting the TZ
+    env var) so that DAILY_RESET_HOUR=0 always means local midnight regardless
+    of the host's UTC offset.  Using datetime.now(timezone.utc) here would
+    cause the reset to fire at UTC midnight — e.g. 7 pm CDT for a US Central
+    family — expiring quests and advancing rotations hours before the family's
+    day actually ends.
     """
     while True:
-        now = datetime.now(timezone.utc)
+        now_local = datetime.now()  # local time — honours TZ env var
         target_hour = settings.DAILY_RESET_HOUR
-        next_run = now.replace(hour=target_hour, minute=0, second=0, microsecond=0)
-        if now >= next_run:
+        next_run = now_local.replace(hour=target_hour, minute=0, second=0, microsecond=0)
+        if now_local >= next_run:
             next_run += timedelta(days=1)
-        wait_seconds = (next_run - now).total_seconds()
+        wait_seconds = (next_run - now_local).total_seconds()
         await asyncio.sleep(wait_seconds)
 
         try:


### PR DESCRIPTION
Fixes #123

## Problem

`daily_reset_task` computed the next fire time using `datetime.now(timezone.utc)`, making `DAILY_RESET_HOUR=0` always mean **UTC midnight** rather than local midnight. For families in UTC-negative time zones (e.g. `TZ=America/Chicago`, CDT = UTC-5), the reset was firing at **7 pm local time**:

- Quests expired with 5 hours left in the family's day
- Rotation `current_index` advanced to tomorrow's kid mid-evening
- Streaks reset before the day was actually over
- New daily assignments appeared at 7 pm instead of midnight

## Fix

One-line change: `datetime.now(timezone.utc)` → `datetime.now()`.

`datetime.now()` without a tz argument uses the process's local clock, which respects the `TZ` environment variable. With `TZ=America/Chicago` and `DAILY_RESET_HOUR=0`, the reset will now fire at **local midnight** as intended.

`date.today()` (used immediately after for `today = date.today()`) was already correct — only the sleep-duration calculation was wrong.

Also added an explanatory comment in `daily_reset_task` so this doesn't get "fixed" back to UTC in the future.

## Bonus: README update needed

The config table in README.md says `DAILY_RESET_HOUR` is "Hour (UTC)" — a follow-up should change that to "Hour (local time, respects TZ)".

## Test plan

- [ ] Set `TZ=America/Chicago` and confirm reset fires at local midnight, not 7 pm
- [ ] Verify quests are not expired before midnight local
- [ ] Verify rotation display stays on today's kid until midnight