### PR TITLE
feat(game): Adventure Mode — Phaser 3 RPG overworld for kids

### DIFF
--- a/.claude/commands/audit-data-integrity.md
+++ b/.claude/commands/audit-data-integrity.md
@@ -1,0 +1,44 @@
+# Data Integrity Audit
+
+Scan for bugs that silently corrupt or lose data — things that don't error
+but produce wrong results over time.
+
+## Patterns to find
+
+### Race conditions / double-spend
+- XP awarded multiple times for the same action (verify called twice before
+  the first commit lands)
+- Spin credits consumed but points not awarded (or vice versa) — is there a
+  transaction wrapping both operations?
+- Streak incremented on every verify call for the same assignment?
+
+### Silent overwrites
+- Any `.replace_all=True` style updates that clobber fields the caller didn't
+  intend to change (like the `assign_chore` current_index reset bug)
+- Upsert patterns that reset state on re-save
+
+### Missing cascade / orphan cleanup
+- Deleting a chore — are its assignments, rules, rotations, exclusions all
+  cleaned up? Or do orphan rows accumulate?
+- Deleting a user — are their assignments, point transactions, achievements,
+  pet state, notifications all handled?
+
+### Off-by-one in date/streak math
+- Any `>` vs `>=` in streak gap checks
+- Grace period cutoff: `< cutoff` vs `<= cutoff`
+- Rotation advancement: `>= 1` vs `> 1` day gap
+
+### Float/int precision in XP
+- Seasonal event multiplier applied as float then truncated — could kids lose
+  1 XP on every quest during an event due to floor vs round?
+- Multi-completion XP scaling — is partial credit calculated correctly?
+
+### Soft-delete consistency
+- `is_active=False` chores: do all list endpoints filter them out?
+  Any place where inactive chores can still receive assignments or be completed?
+
+## Report format
+
+File, line, description of the integrity risk, and recommended fix.
+Low-severity style issues are out of scope — focus on anything that could
+cause silent data loss or incorrect XP/streak values.

--- a/.claude/commands/audit-security.md
+++ b/.claude/commands/audit-security.md
@@ -1,0 +1,42 @@
+# Security Audit
+
+Scan the codebase for common security issues specific to this app's stack
+(FastAPI + SQLAlchemy async + JWT/cookie auth + SQLite + file uploads).
+
+## What to look for
+
+### Auth & authorization
+- Endpoints that use `get_current_user` but never check `user.role` — any kid
+  reaching a parent-only action
+- Endpoints using `require_parent` — verify the decorator is actually applied,
+  not just imported
+- Direct object reference: fetching a record by ID without checking it belongs
+  to the requesting user (e.g. a kid fetching another kid's assignments)
+- API key scope checks — does each scoped endpoint actually enforce the scope,
+  or just check that a key exists?
+
+### File uploads
+- `MAX_UPLOAD_SIZE_MB` enforced on every upload endpoint?
+- Filename sanitization — is `uuid` used for stored filenames everywhere, or
+  is any user-supplied filename used directly?
+- MIME type / extension validation — can a user upload a `.php` or `.html` file?
+
+### Input validation
+- Any `eval()`, `exec()`, or dynamic SQL string interpolation
+- JSON fields stored as raw strings and later parsed without validation
+- Integer overflows in XP/points arithmetic (very large point awards)
+
+### Secrets / data exposure
+- Any endpoint that returns password_hash, api_key raw value, or VAPID keys
+- Error messages that leak stack traces to the client in production
+- Admin-only data leaking through public endpoints (public dashboard, kiosk)
+
+### Rate limiting
+- Authentication endpoints (login, register) — any rate limiting?
+- Photo upload endpoint — can a user spam uploads to fill disk?
+- Spin wheel — server-side enforcement, or just client-side disabled button?
+
+## Report format
+
+For each issue: file, line, severity (critical/high/medium/low), description,
+and recommended fix. Skip anything that's already clearly handled.

--- a/.claude/commands/audit-timezone.md
+++ b/.claude/commands/audit-timezone.md
@@ -1,0 +1,45 @@
+# Timezone & Day-Boundary Audit
+
+Perform a targeted audit of the entire backend for timezone and day-boundary bugs.
+This codebase has been bitten by these repeatedly — the TZ env var sets the container
+to a local timezone (e.g. America/Chicago, CDT = UTC-5), so UTC-midnight != local midnight.
+
+## What to scan for
+
+Search `backend/` for every occurrence of these patterns and evaluate each one:
+
+1. **`datetime.now(timezone.utc)` used for day-boundary logic**
+   - Safe: storing audit timestamps (`created_at`, `updated_at`, `last_used_at`)
+   - Safe: token expiry comparisons (JWT exp, RefreshToken.expires_at)
+   - DANGER: `.replace(hour=0, ...)` to compute "start of today"
+   - DANGER: `.date()` used in a "is this today / is this yesterday?" comparison
+   - DANGER: passed to `should_advance_rotation()` or any function that calls `.date()`
+
+2. **`datetime.utcnow()` anywhere** — deprecated since Python 3.12, and always UTC
+
+3. **Hardcoded timezone strings** (`ZoneInfo('America/Chicago')`, `'US/Central'`, etc.)
+   — should read from `os.environ.get("TZ", "UTC")` instead
+
+4. **`datetime.now(timezone.utc).replace(hour=0, ...)` or `.replace(tzinfo=None)`**
+   — the classic "UTC midnight as today's boundary" mistake
+
+5. **Scheduler / background task timing** — any `asyncio.sleep` loop that computes
+   next-run time; must use local `datetime.now()` not UTC
+
+6. **Frontend `new Date()` comparisons** — JS `Date` is local-time-aware but
+   check any manual ISO string parsing or `.getUTCDate()` / `.getUTCHours()` calls
+   that are used for "is this today?" logic in `frontend/src/`
+
+## For each hit, report
+
+- File + line number
+- The exact pattern found
+- Whether it's safe (UTC is correct for this use) or a bug (should be local time)
+- The fix if it's a bug
+
+## Known-safe patterns (do not flag)
+
+- `datetime.now(timezone.utc)` for `updated_at`, `created_at`, `last_used_at`, `expires_at`
+- `datetime.now(timezone.utc)` compared against other UTC-stored timestamps
+- `date.today()` — already returns local date, always correct
+- `datetime.now()` (no tz arg) — already correct, uses local clock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: sudo apt-get install -y shellcheck
 
       - name: Lint shell scripts
-        run: shellcheck deploy.sh watchdog.sh run-e2e.sh
+        run: shellcheck deploy.sh watchdog.sh run-e2e.sh scripts/audit-patterns.sh
 
       - name: Install docker-compose for smoke test
         run: sudo apt-get install -y docker-compose
@@ -45,6 +45,22 @@ jobs:
           docker-compose config > /dev/null
           echo "✅ docker-compose config OK — .env resolves correctly"
           rm .env
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Job 1b — Code pattern audit (~5 s, no dependencies)
+# Greps for known dangerous antipatterns (UTC midnight as day boundary,
+# hardcoded timezone strings, etc.) that have caused bugs in this codebase.
+# Fails the PR if any ERROR-level pattern is found.
+# ─────────────────────────────────────────────────────────────────────────────
+  pattern-audit:
+    name: Code pattern audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run pattern audit
+        run: bash scripts/audit-patterns.sh
 
   backend-unit-tests:
     name: Backend unit tests

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ __pycache__/
 node_modules/
 dist/
 .env
-data/
+/data/
 *.db
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# ChoreQuest — Claude Code Context
+
+## Project overview
+
+Gamified family chore app. FastAPI backend, React/Vite frontend, SQLite (WAL),
+Docker single-container. Kids earn XP by completing chores; parents manage quests,
+rotations, and rewards.
+
+Key entry points:
+- `backend/main.py` — app startup, daily reset scheduler
+- `backend/routers/` — all API endpoints
+- `backend/services/` — rotation logic, assignment generation, streak service
+- `frontend/src/pages/` — page components
+- `frontend/src/components/` — shared UI
+
+## ⚠️ Known antipatterns — do not repeat these
+
+These bugs have been found and fixed. Flag immediately if you see them again.
+
+### 1. UTC midnight used as a day boundary
+```python
+# WRONG — fires at 7 pm CDT for a US Central family
+datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+
+# CORRECT — respects TZ env var
+datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+```
+Affects: scheduler timing, bounty expiry, any "start of today" cutoff.
+
+### 2. `datetime.now(timezone.utc)` passed to `should_advance_rotation()`
+`should_advance_rotation()` calls `.date()` on the value for calendar-day
+comparisons. UTC `.date()` is already "tomorrow" after 7 pm CDT.
+```python
+# WRONG
+now = datetime.now(timezone.utc)
+should_advance_rotation(rotation, now)
+
+# CORRECT
+now = datetime.now()   # local time
+should_advance_rotation(rotation, now)
+```
+
+### 3. Hardcoded timezone strings
+```python
+# WRONG
+_LOCAL_TZ = ZoneInfo('America/Chicago')
+
+# CORRECT
+_LOCAL_TZ = ZoneInfo(os.environ.get("TZ", "UTC"))
+```
+
+### 4. `assign_chore` resetting rotation state on re-save
+When editing cadence or photo settings without changing `kid_ids`, do NOT
+reset `current_index` or `last_rotated`. Only reset when the kid list changes.
+See `backend/routers/chores.py` — `kids_changed` guard.
+
+### 5. Rotation display trusting `current_index` raw
+After UTC midnight (= 7 pm CDT), `current_index` already points to tomorrow's
+kid. The display layer must prefer today's actual `ChoreAssignment.date` over
+raw `current_index`. See `build_rotation_summaries` in `_chores_helpers.py`.
+
+## Safe vs unsafe `datetime.now` usage
+
+| Pattern | When it's correct |
+|---|---|
+| `datetime.now(timezone.utc)` | Storing audit timestamps (`created_at`, `updated_at`, `expires_at`, `last_used_at`) |
+| `datetime.now(timezone.utc)` | Comparing against other UTC-stored timestamps (token expiry, event ranges) |
+| `datetime.now()` | Scheduler timing, day-boundary comparisons, anything using `.date()` |
+| `date.today()` | Always correct — returns local date |
+
+## Architecture notes
+
+- **Daily reset** fires at `DAILY_RESET_HOUR` in **local time** (respects `TZ`).
+  Code: `datetime.now()` loop in `backend/main.py::daily_reset_task`.
+- **Assignment dates** are stored as `date` (no time component) using local date.
+- **Timestamps** (`created_at` etc.) are stored as naive UTC datetimes (SQLite
+  has no timezone type). `datetime.utcnow` defaults are deprecated — prefer
+  `lambda: datetime.now(timezone.utc)` for new columns.
+- **Rotation `last_rotated`** is stored UTC. `should_advance_rotation` compares
+  `.date()` values — pass local `now` so `.date()` is the local calendar date.
+
+## Audit commands
+
+Run these slash commands periodically or before merging large refactors:
+
+- `/audit-timezone` — find UTC-vs-local day-boundary issues
+- `/audit-security` — auth, file upload, rate limiting, data exposure
+- `/audit-data-integrity` — silent data corruption, race conditions, XP math

--- a/backend/achievements.py
+++ b/backend/achievements.py
@@ -1,7 +1,15 @@
+import os
 from datetime import datetime, date, timezone
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-_LOCAL_TZ = ZoneInfo('America/Chicago')
+# Resolve the container's local timezone from the TZ env var so that
+# "early bird" achievement checks (completion_before_time, all_daily_before_time)
+# use the family's actual local hour rather than a hardcoded zone.
+_tz_name = os.environ.get("TZ", "UTC")
+try:
+    _LOCAL_TZ = ZoneInfo(_tz_name)
+except ZoneInfoNotFoundError:
+    _LOCAL_TZ = ZoneInfo("UTC")
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from backend.models import (

--- a/backend/routers/_chores_helpers.py
+++ b/backend/routers/_chores_helpers.py
@@ -7,7 +7,7 @@ These are internal utilities used across the chores router endpoints:
 - _build_rotation_summaries
 """
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime
 
 from fastapi import HTTPException
 from sqlalchemy import case, select
@@ -110,7 +110,7 @@ async def build_rotation_summaries(
     kid_names: dict[int, str] = {row.id: row.display_name for row in kid_result.all()}
 
     today = date.today()
-    now = datetime.now(timezone.utc)
+    now = datetime.now()  # local time — only used for should_advance_rotation .date() check
 
     # Batch-load today's actual assignments for all rotation chores so we can
     # ground the "currently X's turn" display in what was really scheduled for

--- a/backend/routers/bounty.py
+++ b/backend/routers/bounty.py
@@ -6,7 +6,9 @@ completion rate because they live in bounty_board_claims, not
 chore_assignments.
 """
 
+import os
 from datetime import datetime, date, timezone, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile, File
 from sqlalchemy import select, delete, update
@@ -646,9 +648,16 @@ async def expire_stale_bounty_claims(db: AsyncSession) -> None:
     In-progress claims (claimed/completed) are intentionally left alone.
     Kids are notified so they know the board has refreshed.
     """
-    # Use local midnight (respects TZ env var) so bounties reset at the family's
-    # end-of-day rather than UTC midnight (which is 7 pm CDT for US Central).
-    today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    # Compute local midnight as naive UTC so it compares correctly against the
+    # naive-UTC values stored in BountyBoardClaim.verified_at.
+    # Strategy: get aware local midnight → convert to UTC → strip tzinfo.
+    _tz_name = os.environ.get("TZ", "UTC")
+    try:
+        _local_tz = ZoneInfo(_tz_name)
+    except ZoneInfoNotFoundError:
+        _local_tz = ZoneInfo("UTC")
+    local_midnight = datetime.now(_local_tz).replace(hour=0, minute=0, second=0, microsecond=0)
+    today_start = local_midnight.astimezone(timezone.utc).replace(tzinfo=None)
 
     # Fetch affected claims before deleting so we can notify the kids
     stale_result = await db.execute(

--- a/backend/routers/bounty.py
+++ b/backend/routers/bounty.py
@@ -646,7 +646,9 @@ async def expire_stale_bounty_claims(db: AsyncSession) -> None:
     In-progress claims (claimed/completed) are intentionally left alone.
     Kids are notified so they know the board has refreshed.
     """
-    today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
+    # Use local midnight (respects TZ env var) so bounties reset at the family's
+    # end-of-day rather than UTC midnight (which is 7 pm CDT for US Central).
+    today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
     # Fetch affected claims before deleting so we can notify the kids
     stale_result = await db.execute(

--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -869,7 +869,7 @@ async def complete_chore(
     user: User = Depends(get_current_user),
 ):
     today = date.today()
-    now = datetime.now()  # local time — should_advance_rotation uses now.date() for day-boundary checks
+    now = datetime.now(timezone.utc)
 
     grace_result = await db.execute(
         select(AppSetting).where(AppSetting.key == "grace_period_days")
@@ -1028,7 +1028,7 @@ async def verify_chore(
     user: User = Depends(require_parent),
 ):
     today = date.today()
-    now = datetime.now()  # local time — should_advance_rotation uses now.date() for day-boundary checks
+    now = datetime.now(timezone.utc)
 
     filters = [
         ChoreAssignment.chore_id == chore_id,
@@ -1184,7 +1184,7 @@ async def parent_verify_assignment(
     exactly as the normal verify flow does.
     """
     today = date.today()
-    now = datetime.now()  # local time — should_advance_rotation uses now.date() for day-boundary checks
+    now = datetime.now(timezone.utc)
 
     result = await db.execute(
         select(ChoreAssignment)
@@ -1371,7 +1371,7 @@ async def uncomplete_chore(
     user: User = Depends(require_parent),
 ):
     today = date.today()
-    now = datetime.now()  # local time — should_advance_rotation uses now.date() for day-boundary checks
+    now = datetime.now(timezone.utc)
 
     filters = [
         ChoreAssignment.chore_id == chore_id,
@@ -1463,7 +1463,7 @@ async def skip_chore(
     user: User = Depends(require_parent),
 ):
     today = date.today()
-    now = datetime.now()  # local time — should_advance_rotation uses now.date() for day-boundary checks
+    now = datetime.now(timezone.utc)
 
     filters = [
         ChoreAssignment.chore_id == chore_id,

--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -869,7 +869,7 @@ async def complete_chore(
     user: User = Depends(get_current_user),
 ):
     today = date.today()
-    now = datetime.now(timezone.utc)
+    now = datetime.now()  # local time — should_advance_rotation uses now.date() for day-boundary checks
 
     grace_result = await db.execute(
         select(AppSetting).where(AppSetting.key == "grace_period_days")
@@ -1028,7 +1028,7 @@ async def verify_chore(
     user: User = Depends(require_parent),
 ):
     today = date.today()
-    now = datetime.now(timezone.utc)
+    now = datetime.now()  # local time — should_advance_rotation uses now.date() for day-boundary checks
 
     filters = [
         ChoreAssignment.chore_id == chore_id,
@@ -1184,7 +1184,7 @@ async def parent_verify_assignment(
     exactly as the normal verify flow does.
     """
     today = date.today()
-    now = datetime.now(timezone.utc)
+    now = datetime.now()  # local time — should_advance_rotation uses now.date() for day-boundary checks
 
     result = await db.execute(
         select(ChoreAssignment)
@@ -1371,7 +1371,7 @@ async def uncomplete_chore(
     user: User = Depends(require_parent),
 ):
     today = date.today()
-    now = datetime.now(timezone.utc)
+    now = datetime.now()  # local time — should_advance_rotation uses now.date() for day-boundary checks
 
     filters = [
         ChoreAssignment.chore_id == chore_id,
@@ -1463,7 +1463,7 @@ async def skip_chore(
     user: User = Depends(require_parent),
 ):
     today = date.today()
-    now = datetime.now(timezone.utc)
+    now = datetime.now()  # local time — should_advance_rotation uses now.date() for day-boundary checks
 
     filters = [
         ChoreAssignment.chore_id == chore_id,

--- a/backend/services/assignment_generator.py
+++ b/backend/services/assignment_generator.py
@@ -110,7 +110,12 @@ async def generate_daily_assignments(db: AsyncSession, today: date) -> None:
         logger.info("Skipping assignment generation — vacation day %s", today)
         return
 
-    now = datetime.now()  # local time — should_advance_rotation uses now.date() for day-boundary checks
+    # Two separate now values:
+    #   now_local — naive local time used by should_advance_rotation for .date() day-boundary checks
+    #   now_utc   — tz-aware UTC stored in rotation.last_rotated, consistent with all other writers
+    #               (rotations.py:57, chores.py:547,555 all use datetime.now(timezone.utc))
+    now_local = datetime.now()
+    now_utc = datetime.now(timezone.utc)
     chores = await _load_active_chores(db)
 
     for chore in chores:
@@ -137,8 +142,8 @@ async def generate_daily_assignments(db: AsyncSession, today: date) -> None:
             ]
 
             # Only advance rotation on days the chore actually runs
-            if rotation and active_rules and should_advance_rotation(rotation, now):
-                await advance_rotation_and_mirror(rotation, db, now)
+            if rotation and active_rules and should_advance_rotation(rotation, now_local):
+                await advance_rotation_and_mirror(rotation, db, now_utc)
 
             for rule in active_rules:
                 # Rotation filtering: only generate for the current rotation kid
@@ -169,8 +174,8 @@ async def generate_daily_assignments(db: AsyncSession, today: date) -> None:
 
             rotation = await _load_rotation(db, chore.id)
             if rotation:
-                if should_advance_rotation(rotation, now):
-                    await advance_rotation_and_mirror(rotation, db, now)
+                if should_advance_rotation(rotation, now_local):
+                    await advance_rotation_and_mirror(rotation, db, now_utc)
                 user_ids = [rotation.kid_ids[rotation.current_index]]
             else:
                 user_ids = await _get_legacy_user_ids(db, chore.id)

--- a/backend/services/assignment_generator.py
+++ b/backend/services/assignment_generator.py
@@ -110,7 +110,7 @@ async def generate_daily_assignments(db: AsyncSession, today: date) -> None:
         logger.info("Skipping assignment generation — vacation day %s", today)
         return
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now()  # local time — should_advance_rotation uses now.date() for day-boundary checks
     chores = await _load_active_chores(db)
 
     for chore in chores:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "framer-motion": "^11.15.0",
         "lucide-react": "^0.468.0",
+        "phaser": "^3.88.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.28.0"
@@ -1679,6 +1680,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2147,6 +2154,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/phaser": {
+      "version": "3.88.2",
+      "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.88.2.tgz",
+      "integrity": "sha512-UBgd2sAFuRJbF2xKaQ5jpMWB8oETncChLnymLGHcrnT53vaqiGrQWbUKUDBawKLm24sghjKo4Bf+/xfv8espZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,16 +10,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "framer-motion": "^11.15.0",
+    "lucide-react": "^0.468.0",
+    "phaser": "^3.88.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.0",
-    "lucide-react": "^0.468.0",
-    "framer-motion": "^11.15.0"
+    "react-router-dom": "^6.28.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.3.4",
-    "vite": "^6.4.2",
     "@tailwindcss/vite": "^4.0.0",
-    "tailwindcss": "^4.0.0"
+    "@vitejs/plugin-react": "^4.3.4",
+    "tailwindcss": "^4.0.0",
+    "vite": "^6.4.2"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -182,7 +182,7 @@ export default function App() {
             <Route path="/kids/:kidId" element={<Page pageKey="kid-quests"><KidQuests /></Page>} />
             <Route path="/bounty" element={<Page pageKey="bounty"><BountyBoard /></Page>} />
             <Route path="/settings" element={<Page pageKey="settings"><Settings /></Page>} />
-            <Route path="/adventure" element={<Page pageKey="adventure"><AdventureMode /></Page>} />
+            {user.role === 'kid' && <Route path="/adventure" element={<Page pageKey="adventure"><AdventureMode /></Page>} />}
             {user.role === 'admin' && <Route path="/admin" element={<Page pageKey="admin"><AdminDashboard /></Page>} />}
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,7 @@ const Party = lazy(() => import('./pages/Party'));
 const BountyBoard = lazy(() => import('./pages/BountyBoard'));
 const AvatarEditor = lazy(() => import('./components/AvatarEditor'));
 const PublicDashboard = lazy(() => import('./pages/PublicDashboard'));
+const AdventureMode = lazy(() => import('./pages/AdventureMode'));
 
 function Loading() {
   return (
@@ -181,6 +182,7 @@ export default function App() {
             <Route path="/kids/:kidId" element={<Page pageKey="kid-quests"><KidQuests /></Page>} />
             <Route path="/bounty" element={<Page pageKey="bounty"><BountyBoard /></Page>} />
             <Route path="/settings" element={<Page pageKey="settings"><Settings /></Page>} />
+            <Route path="/adventure" element={<Page pageKey="adventure"><AdventureMode /></Page>} />
             {user.role === 'admin' && <Route path="/admin" element={<Page pageKey="admin"><AdminDashboard /></Page>} />}
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/frontend/src/game/chore-portals/PortalManager.js
+++ b/frontend/src/game/chore-portals/PortalManager.js
@@ -1,0 +1,88 @@
+// Creates portal sprites on the map and handles zone entry detection.
+// Emits 'portalEnter' scene event when player walks into a portal zone.
+
+import { PORTAL_ZONES, TILE_SIZE } from '../data/WorldData.js';
+
+export class PortalManager {
+  constructor(scene) {
+    this.scene   = scene;
+    this.portals = scene.physics.add.staticGroup();
+    this._createPortals();
+  }
+
+  _createPortals() {
+    PORTAL_ZONES.forEach((zone) => {
+      const px = zone.x * TILE_SIZE + TILE_SIZE / 2;
+      const py = zone.y * TILE_SIZE + TILE_SIZE / 2;
+
+      const portal = this.portals.create(px, py, 'portal');
+      portal.zoneData  = zone;
+      portal.setDepth(8);
+      portal.body.setSize(TILE_SIZE * 1.5, TILE_SIZE * 1.5);
+
+      // Glow tint cycling
+      this.scene.tweens.add({
+        targets: portal,
+        alpha: 0.7,
+        duration: 800,
+        yoyo: true,
+        repeat: -1,
+        ease: 'Sine.easeInOut',
+      });
+
+      // Label with dark background for readability
+      const label = this.scene.add.text(px, py - 30, zone.label, {
+        fontSize: '11px',
+        fontFamily: 'monospace',
+        color: '#fcd860',
+        stroke: '#000000',
+        strokeThickness: 4,
+        resolution: 2,
+      }).setOrigin(0.5).setDepth(15);
+
+      const labelBg = this.scene.add.rectangle(
+        px, py - 30, label.width + 14, 18, 0x000000, 0.7,
+      ).setOrigin(0.5).setDepth(14);
+
+      const hint = this.scene.add.text(px, py - 14, 'walk in to enter', {
+        fontSize: '8px',
+        fontFamily: 'monospace',
+        color: '#aaffaa',
+        stroke: '#000000',
+        strokeThickness: 3,
+        resolution: 2,
+      }).setOrigin(0.5).setDepth(15);
+
+      portal.label    = label;
+      portal.labelBg  = labelBg;
+      portal.hintText = hint;
+    });
+
+    // Animate portal frames
+    if (!this.scene.anims.exists('portal_spin')) {
+      this.scene.anims.create({
+        key: 'portal_spin',
+        frames: this.scene.anims.generateFrameNumbers('portal', { start: 0, end: 3 }),
+        frameRate: 4,
+        repeat: -1,
+      });
+    }
+    this.portals.getChildren().forEach((p) => p.play('portal_spin'));
+  }
+
+  addOverlap(player) {
+    this.scene.physics.add.overlap(player, this.portals, (_player, portal) => {
+      this.scene.events.emit('portalEnter', portal.zoneData);
+    });
+  }
+
+  setRestoreLevel(zoneId, level) {
+    // Visually tint portal to show restoration progress
+    const child = this.portals.getChildren().find(
+      (p) => p.zoneData.id === zoneId
+    );
+    if (!child) return;
+    const tints = [0xffffff, 0xaaffaa, 0x44ff44, 0x00cc00];
+    child.setTint(tints[Math.min(level, 3)]);
+  }
+}

--- a/frontend/src/game/chore-portals/QuestPortalOverlay.jsx
+++ b/frontend/src/game/chore-portals/QuestPortalOverlay.jsx
@@ -1,0 +1,242 @@
+// Quest portal popup — shown over the Phaser canvas when the player enters a portal.
+// Fetches real chores from the API and lets the player accept/complete them.
+
+import { useState, useEffect } from 'react';
+import { api } from '../../api/client.js';
+
+const DIFFICULTY_COLORS = {
+  easy:   '#58d854',
+  medium: '#fcd860',
+  hard:   '#f87858',
+};
+
+function DifficultyBadge({ difficulty }) {
+  const d = (difficulty ?? 'easy').toLowerCase();
+  const color = DIFFICULTY_COLORS[d] ?? '#bcbcbc';
+  return (
+    <span style={{
+      fontFamily: 'monospace', fontSize: 10, color,
+      border: `1px solid ${color}`, borderRadius: 3,
+      padding: '1px 5px', textTransform: 'uppercase',
+    }}>
+      {d}
+    </span>
+  );
+}
+
+export function QuestPortalOverlay({ zone, gameData, onClose, onChoreComplete }) {
+  const [chores, setChores]   = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [doing, setDoing]     = useState(null);
+  const [flash, setFlash]     = useState(null);
+
+  useEffect(() => {
+    if (!zone) return;
+    setLoading(true);
+    api('/api/chores/assignments?status=pending')
+      .then((data) => {
+        const list = (data ?? []).filter((a) => {
+          if (!zone.choreCategories?.length) return true;
+          const cat = (a.category ?? a.chore?.category ?? '').toLowerCase();
+          return zone.choreCategories.some((c) => cat.includes(c.toLowerCase()));
+        });
+        setChores(list.slice(0, 6));
+      })
+      .catch(() => setChores([]))
+      .finally(() => setLoading(false));
+  }, [zone]);
+
+  async function handleComplete(assignment) {
+    setDoing(assignment.id);
+    try {
+      await api(`/api/chores/assignments/${assignment.id}/complete`, { method: 'POST' });
+      const xpGained    = assignment.xp_reward ?? assignment.chore?.xp_value ?? 50;
+      const coinsGained = Math.floor(xpGained / 10);
+      setFlash({ xp: xpGained, coins: coinsGained });
+      onChoreComplete({ assignment, xpGained, coinsGained });
+      setChores((prev) => prev.filter((c) => c.id !== assignment.id));
+      setTimeout(() => setFlash(null), 2000);
+    } catch (err) {
+      console.warn('[QuestPortal] complete failed', err);
+    } finally {
+      setDoing(null);
+    }
+  }
+
+  if (!zone) return null;
+
+  return (
+    <div style={{
+      position: 'absolute', inset: 0,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      background: 'rgba(0,0,0,0.72)',
+      zIndex: 50,
+      fontFamily: 'monospace',
+    }}>
+      {/* Flash reward */}
+      {flash && (
+        <div style={{
+          position: 'absolute', top: '30%', left: '50%', transform: 'translate(-50%,-50%)',
+          textAlign: 'center', pointerEvents: 'none',
+          animation: 'fadeup 1.8s ease forwards',
+        }}>
+          <div style={{ fontSize: 28, color: '#58d854', textShadow: '0 2px 8px #000' }}>
+            +{flash.xp} XP
+          </div>
+          <div style={{ fontSize: 18, color: '#fcd860', marginTop: 4 }}>
+            +{flash.coins} Coins
+          </div>
+        </div>
+      )}
+
+      <div style={{
+        background: '#1a1a1a',
+        border: '2px solid #3a3a3a',
+        borderRadius: 8,
+        padding: 20,
+        width: Math.min(380, window.innerWidth - 32),
+        maxHeight: '80vh',
+        overflowY: 'auto',
+        position: 'relative',
+      }}>
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
+          <div style={{
+            width: 12, height: 12, borderRadius: 2,
+            background: `#${zone.color?.toString(16).padStart(6,'0') ?? 'ffffff'}`,
+          }} />
+          <div>
+            <div style={{ fontSize: 14, color: '#fcd860', fontWeight: 700 }}>
+              {zone.label}
+            </div>
+            <div style={{ fontSize: 9, color: '#888' }}>{zone.description}</div>
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              marginLeft: 'auto', background: 'none', border: 'none',
+              color: '#888', fontSize: 16, cursor: 'pointer',
+            }}
+          >✕</button>
+        </div>
+
+        {/* Reward Castle special case */}
+        {zone.isRewardShop && (
+          <div style={{ color: '#bcbcbc', fontSize: 11, textAlign: 'center', padding: '16px 0' }}>
+            <div style={{ fontSize: 20, marginBottom: 8 }}>🏰</div>
+            <div>Coins: <strong style={{ color: '#fcd860' }}>{gameData?.coins ?? 0}</strong></div>
+            <div style={{ marginTop: 8, fontSize: 9, color: '#666' }}>
+              Visit the Rewards page in ChoreQuest to redeem your coins for prizes!
+            </div>
+            <button
+              onClick={onClose}
+              style={{
+                marginTop: 12, padding: '8px 24px',
+                background: '#d4a017', border: 'none', borderRadius: 4,
+                color: '#000', fontFamily: 'monospace', fontSize: 11, cursor: 'pointer',
+              }}
+            >
+              Continue Adventure
+            </button>
+          </div>
+        )}
+
+        {/* Quest list */}
+        {!zone.isRewardShop && (
+          <>
+            <div style={{ fontSize: 9, color: '#888', marginBottom: 8 }}>
+              Active quests in this district:
+            </div>
+
+            {loading && (
+              <div style={{ color: '#666', fontSize: 10, textAlign: 'center', padding: 16 }}>
+                Loading quests...
+              </div>
+            )}
+
+            {!loading && chores.length === 0 && (
+              <div style={{
+                color: '#666', fontSize: 10, textAlign: 'center', padding: 16,
+                border: '1px dashed #333', borderRadius: 6,
+              }}>
+                No active quests here right now.<br />
+                <span style={{ fontSize: 9, color: '#555' }}>Check back after the daily reset!</span>
+              </div>
+            )}
+
+            {chores.map((a) => {
+              const chore = a.chore ?? a;
+              const xp    = a.xp_reward ?? chore.xp_value ?? 50;
+              const coins = Math.floor(xp / 10);
+              const diff  = chore.difficulty ?? 'easy';
+              const isDoing = doing === a.id;
+
+              return (
+                <div
+                  key={a.id}
+                  style={{
+                    background: '#252525',
+                    border: '1px solid #333',
+                    borderRadius: 6,
+                    padding: '10px 12px',
+                    marginBottom: 8,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 6,
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+                    <div style={{ flex: 1 }}>
+                      <div style={{ fontSize: 12, color: '#e5e5e5', fontWeight: 600 }}>
+                        {chore.name ?? chore.title ?? 'Chore Quest'}
+                      </div>
+                      {chore.description && (
+                        <div style={{ fontSize: 9, color: '#666', marginTop: 2 }}>
+                          {chore.description}
+                        </div>
+                      )}
+                    </div>
+                    <DifficultyBadge difficulty={diff} />
+                  </div>
+
+                  <div style={{ display: 'flex', gap: 12, fontSize: 9, color: '#888' }}>
+                    <span style={{ color: '#58d854' }}>+{xp} XP</span>
+                    <span style={{ color: '#fcd860' }}>+{coins} coins</span>
+                    {chore.allowance_value > 0 && (
+                      <span style={{ color: '#14b8a6' }}>${chore.allowance_value.toFixed(2)}</span>
+                    )}
+                  </div>
+
+                  <button
+                    onClick={() => handleComplete(a)}
+                    disabled={isDoing}
+                    style={{
+                      padding: '6px 12px',
+                      background: isDoing ? '#333' : '#10b981',
+                      border: 'none', borderRadius: 4,
+                      color: isDoing ? '#666' : '#000',
+                      fontFamily: 'monospace', fontSize: 10,
+                      cursor: isDoing ? 'not-allowed' : 'pointer',
+                      fontWeight: 700,
+                      transition: 'background 0.15s',
+                    }}
+                  >
+                    {isDoing ? 'Completing...' : '✓ Mark Complete'}
+                  </button>
+                </div>
+              );
+            })}
+          </>
+        )}
+      </div>
+
+      <style>{`
+        @keyframes fadeup {
+          0%   { opacity: 1; transform: translate(-50%,-50%); }
+          80%  { opacity: 1; transform: translate(-50%,-80%); }
+          100% { opacity: 0; transform: translate(-50%,-100%); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/src/game/chore-portals/QuestPortalOverlay.jsx
+++ b/frontend/src/game/chore-portals/QuestPortalOverlay.jsx
@@ -1,5 +1,9 @@
 // Quest portal popup — shown over the Phaser canvas when the player enters a portal.
-// Fetches real chores from the API and lets the player accept/complete them.
+// Fetches today's pending assignments from /api/calendar and lets the player mark them done.
+// Completing a chore here calls POST /api/chores/{chore_id}/complete (same as the main app),
+// which marks the assignment completed and awaits parent verification for real points.
+// XP and coins shown in-game are a cosmetic "adventure currency" that mirrors chore.points —
+// they are intentionally separate from the app's verified PointTransaction system.
 
 import { useState, useEffect } from 'react';
 import { api } from '../../api/client.js';
@@ -33,12 +37,18 @@ export function QuestPortalOverlay({ zone, gameData, onClose, onChoreComplete })
   useEffect(() => {
     if (!zone) return;
     setLoading(true);
-    api('/api/chores/assignments?status=pending')
+
+    // GET /api/calendar defaults to the current week; we pull today's pending slice.
+    const today = new Date().toISOString().split('T')[0];
+    api('/api/calendar')
       .then((data) => {
-        const list = (data ?? []).filter((a) => {
+        const todayAssignments = data.days?.[today] ?? [];
+        const list = todayAssignments.filter((a) => {
+          if (a.status !== 'pending') return false;
           if (!zone.choreCategories?.length) return true;
-          const cat = (a.category ?? a.chore?.category ?? '').toLowerCase();
-          return zone.choreCategories.some((c) => cat.includes(c.toLowerCase()));
+          // category is a nested object: { id, name, icon, colour, is_default }
+          const catName = (a.chore?.category?.name ?? '').toLowerCase();
+          return zone.choreCategories.some((c) => catName.includes(c.toLowerCase()));
         });
         setChores(list.slice(0, 6));
       })
@@ -49,8 +59,12 @@ export function QuestPortalOverlay({ zone, gameData, onClose, onChoreComplete })
   async function handleComplete(assignment) {
     setDoing(assignment.id);
     try {
-      await api(`/api/chores/assignments/${assignment.id}/complete`, { method: 'POST' });
-      const xpGained    = assignment.xp_reward ?? assignment.chore?.xp_value ?? 50;
+      // Correct endpoint: POST /api/chores/{chore_id}/complete
+      // This auto-finds today's pending assignment for the logged-in kid.
+      await api(`/api/chores/${assignment.chore_id}/complete`, { method: 'POST' });
+
+      // chore.points is the backend reward value; use it as adventure XP.
+      const xpGained    = assignment.chore?.points ?? 50;
       const coinsGained = Math.floor(xpGained / 10);
       setFlash({ xp: xpGained, coins: coinsGained });
       onChoreComplete({ assignment, xpGained, coinsGained });
@@ -64,6 +78,9 @@ export function QuestPortalOverlay({ zone, gameData, onClose, onChoreComplete })
   }
 
   if (!zone) return null;
+
+  // zone.color is a hex number (e.g. 0xff6644); convert to CSS colour string.
+  const zoneColorCss = `#${(zone.color ?? 0xffffff).toString(16).padStart(6, '0')}`;
 
   return (
     <div style={{
@@ -103,7 +120,7 @@ export function QuestPortalOverlay({ zone, gameData, onClose, onChoreComplete })
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 12 }}>
           <div style={{
             width: 12, height: 12, borderRadius: 2,
-            background: `#${zone.color?.toString(16).padStart(6,'0') ?? 'ffffff'}`,
+            background: zoneColorCss,
           }} />
           <div>
             <div style={{ fontSize: 14, color: '#fcd860', fontWeight: 700 }}>
@@ -165,10 +182,12 @@ export function QuestPortalOverlay({ zone, gameData, onClose, onChoreComplete })
             )}
 
             {chores.map((a) => {
-              const chore = a.chore ?? a;
-              const xp    = a.xp_reward ?? chore.xp_value ?? 50;
-              const coins = Math.floor(xp / 10);
-              const diff  = chore.difficulty ?? 'easy';
+              // AssignmentResponse fields: id, chore_id, status, chore (ChoreResponse)
+              // ChoreResponse fields: title, points, difficulty, description, category.name
+              const chore   = a.chore ?? {};
+              const xp      = chore.points ?? 50;
+              const coins   = Math.floor(xp / 10);
+              const diff    = chore.difficulty ?? 'easy';
               const isDoing = doing === a.id;
 
               return (
@@ -188,7 +207,7 @@ export function QuestPortalOverlay({ zone, gameData, onClose, onChoreComplete })
                   <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
                     <div style={{ flex: 1 }}>
                       <div style={{ fontSize: 12, color: '#e5e5e5', fontWeight: 600 }}>
-                        {chore.name ?? chore.title ?? 'Chore Quest'}
+                        {chore.title ?? 'Chore Quest'}
                       </div>
                       {chore.description && (
                         <div style={{ fontSize: 9, color: '#666', marginTop: 2 }}>
@@ -202,9 +221,6 @@ export function QuestPortalOverlay({ zone, gameData, onClose, onChoreComplete })
                   <div style={{ display: 'flex', gap: 12, fontSize: 9, color: '#888' }}>
                     <span style={{ color: '#58d854' }}>+{xp} XP</span>
                     <span style={{ color: '#fcd860' }}>+{coins} coins</span>
-                    {chore.allowance_value > 0 && (
-                      <span style={{ color: '#14b8a6' }}>${chore.allowance_value.toFixed(2)}</span>
-                    )}
                   </div>
 
                   <button

--- a/frontend/src/game/chore-portals/QuestPortalOverlay.jsx
+++ b/frontend/src/game/chore-portals/QuestPortalOverlay.jsx
@@ -7,6 +7,8 @@
 
 import { useState, useEffect } from 'react';
 import { api } from '../../api/client.js';
+import { useAuth } from '../../hooks/useAuth.jsx';
+import { toLocalISO } from '../../utils/dates.js';
 
 const DIFFICULTY_COLORS = {
   easy:   '#58d854',
@@ -29,6 +31,7 @@ function DifficultyBadge({ difficulty }) {
 }
 
 export function QuestPortalOverlay({ zone, gameData, onClose, onChoreComplete }) {
+  const { user }              = useAuth();
   const [chores, setChores]   = useState([]);
   const [loading, setLoading] = useState(true);
   const [doing, setDoing]     = useState(null);
@@ -38,13 +41,17 @@ export function QuestPortalOverlay({ zone, gameData, onClose, onChoreComplete })
     if (!zone) return;
     setLoading(true);
 
-    // GET /api/calendar defaults to the current week; we pull today's pending slice.
-    const today = new Date().toISOString().split('T')[0];
+    // GET /api/calendar defaults to the current week; pull today's slice.
+    // toLocalISO() uses the local calendar date (not UTC) — critical after ~7pm
+    // in western timezones where new Date().toISOString() returns tomorrow's date.
+    const today = toLocalISO();
     api('/api/calendar')
       .then((data) => {
         const todayAssignments = data.days?.[today] ?? [];
         const list = todayAssignments.filter((a) => {
           if (a.status !== 'pending') return false;
+          // Filter to the current user only — /api/calendar returns all family members.
+          if (user && a.user_id !== user.id) return false;
           if (!zone.choreCategories?.length) return true;
           // category is a nested object: { id, name, icon, colour, is_default }
           const catName = (a.chore?.category?.name ?? '').toLowerCase();
@@ -54,7 +61,7 @@ export function QuestPortalOverlay({ zone, gameData, onClose, onChoreComplete })
       })
       .catch(() => setChores([]))
       .finally(() => setLoading(false));
-  }, [zone]);
+  }, [zone, user]);
 
   async function handleComplete(assignment) {
     setDoing(assignment.id);

--- a/frontend/src/game/data/WorldData.js
+++ b/frontend/src/game/data/WorldData.js
@@ -17,6 +17,8 @@ export const MAP_ROWS = 40;
 export const TILE_SIZE = 32;
 
 // Portal zone categories — map to ChoreQuest chore categories
+// choreCategories must match the seeded category names in backend/seed.py:
+// Kitchen, Bedroom, Bathroom, Garden, Pets, Homework, Laundry, General, Outdoor
 export const PORTAL_ZONES = [
   {
     id: 'kitchen',
@@ -24,7 +26,7 @@ export const PORTAL_ZONES = [
     x: 10, y: 8,
     buildingKey: 'building_kitchen',
     color: 0xff6644,
-    choreCategories: ['Kitchen', 'Dishes', 'Cooking'],
+    choreCategories: ['Kitchen'],
     description: 'Culinary quests await inside!',
     restoreLevel: 0,
   },
@@ -34,7 +36,7 @@ export const PORTAL_ZONES = [
     x: 28, y: 8,
     buildingKey: 'building_laundry',
     color: 0x6688ff,
-    choreCategories: ['Laundry', 'Clothes', 'Bedroom'],
+    choreCategories: ['Laundry', 'Bedroom'],
     description: 'Tame the wild laundry beasts!',
     restoreLevel: 0,
   },
@@ -44,7 +46,7 @@ export const PORTAL_ZONES = [
     x: 10, y: 28,
     buildingKey: null,
     color: 0x44cc44,
-    choreCategories: ['Yard', 'Outside', 'Garden', 'Pets'],
+    choreCategories: ['Garden', 'Pets', 'Outdoor'],
     description: 'The wild outdoors beckons.',
     restoreLevel: 0,
   },
@@ -54,7 +56,7 @@ export const PORTAL_ZONES = [
     x: 28, y: 28,
     buildingKey: null,
     color: 0xffcc00,
-    choreCategories: ['Homework', 'Study', 'School'],
+    choreCategories: ['Homework'],
     description: 'Knowledge is power!',
     restoreLevel: 0,
   },

--- a/frontend/src/game/data/WorldData.js
+++ b/frontend/src/game/data/WorldData.js
@@ -1,0 +1,200 @@
+// World map layout and chore portal definitions.
+// Tile indices: 0=grass, 1=dirt, 2=water, 3=path, 4=tree_top, 5=tree_bot, 6=wall, 7=flower
+
+export const TILE = {
+  GRASS: 0,
+  DIRT:  1,
+  WATER: 2,
+  PATH:  3,
+  TREE_TOP: 4,
+  TREE_BOT: 5,
+  WALL:  6,
+  FLOWER: 7,
+};
+
+export const MAP_COLS = 40;
+export const MAP_ROWS = 40;
+export const TILE_SIZE = 32;
+
+// Portal zone categories — map to ChoreQuest chore categories
+export const PORTAL_ZONES = [
+  {
+    id: 'kitchen',
+    label: 'Kitchen District',
+    x: 10, y: 8,
+    buildingKey: 'building_kitchen',
+    color: 0xff6644,
+    choreCategories: ['Kitchen', 'Dishes', 'Cooking'],
+    description: 'Culinary quests await inside!',
+    restoreLevel: 0,
+  },
+  {
+    id: 'laundry',
+    label: 'Laundry Hut',
+    x: 28, y: 8,
+    buildingKey: 'building_laundry',
+    color: 0x6688ff,
+    choreCategories: ['Laundry', 'Clothes', 'Bedroom'],
+    description: 'Tame the wild laundry beasts!',
+    restoreLevel: 0,
+  },
+  {
+    id: 'yard',
+    label: 'Yard Entrance',
+    x: 10, y: 28,
+    buildingKey: null,
+    color: 0x44cc44,
+    choreCategories: ['Yard', 'Outside', 'Garden', 'Pets'],
+    description: 'The wild outdoors beckons.',
+    restoreLevel: 0,
+  },
+  {
+    id: 'study',
+    label: 'Study Hall',
+    x: 28, y: 28,
+    buildingKey: null,
+    color: 0xffcc00,
+    choreCategories: ['Homework', 'Study', 'School'],
+    description: 'Knowledge is power!',
+    restoreLevel: 0,
+  },
+  {
+    id: 'castle',
+    label: 'Reward Castle',
+    x: 19, y: 18,
+    buildingKey: 'building_reward_castle',
+    color: 0xffdd00,
+    choreCategories: [],
+    description: 'Redeem your hard-earned rewards!',
+    restoreLevel: 0,
+    isRewardShop: true,
+  },
+];
+
+// Enemy spawn zones
+export const ENEMY_ZONES = [
+  { type: 'dust_bunny',  x: 6,  y: 15, count: 2 },
+  { type: 'dust_bunny',  x: 33, y: 15, count: 2 },
+  { type: 'sock_goblin', x: 6,  y: 22, count: 2 },
+  { type: 'sock_goblin', x: 33, y: 22, count: 2 },
+  { type: 'crumb_slime', x: 18, y: 6,  count: 2 },
+  { type: 'crumb_slime', x: 18, y: 32, count: 2 },
+];
+
+export const ENEMY_STATS = {
+  dust_bunny:  { hp: 8,  xp: 2, coins: 1, name: 'Dust Bunny',  speed: 60 },
+  sock_goblin: { hp: 12, xp: 3, coins: 2, name: 'Sock Goblin', speed: 50 },
+  crumb_slime: { hp: 6,  xp: 1, coins: 1, name: 'Crumb Slime', speed: 40 },
+};
+
+// Weapons / attacks
+export const WEAPON_STATS = {
+  broom:   { damage: 3, range: 72,  cooldown: 500,  name: 'Broom Swipe' },
+  vacuum:  { damage: 4, range: 88,  cooldown: 800,  name: 'Vacuum Blast' },
+  soap:    { damage: 5, range: 56,  cooldown: 1000, name: 'Soap Attack' },
+  sponge:  { damage: 2, range: 120, cooldown: 600,  name: 'Toss Sponge' },
+};
+
+// XP table: level -> xp needed to reach NEXT level
+export function xpForLevel(level) {
+  return Math.floor(100 * Math.pow(1.4, level - 1));
+}
+
+export function levelFromXp(xp) {
+  let lvl = 1;
+  let accumulated = 0;
+  while (accumulated + xpForLevel(lvl) <= xp) {
+    accumulated += xpForLevel(lvl);
+    lvl++;
+    if (lvl > 99) break;
+  }
+  return lvl;
+}
+
+// Build the base tile grid (40x40)
+export function buildBaseMap() {
+  const grid = [];
+
+  for (let row = 0; row < MAP_ROWS; row++) {
+    grid[row] = [];
+    for (let col = 0; col < MAP_COLS; col++) {
+      // Default: grass
+      grid[row][col] = TILE.GRASS;
+    }
+  }
+
+  // Water border (top/bottom)
+  for (let col = 0; col < MAP_COLS; col++) {
+    grid[0][col] = TILE.WATER;
+    grid[1][col] = TILE.WATER;
+    grid[MAP_ROWS - 1][col] = TILE.WATER;
+    grid[MAP_ROWS - 2][col] = TILE.WATER;
+  }
+  // Water border (left/right)
+  for (let row = 0; row < MAP_ROWS; row++) {
+    grid[row][0] = TILE.WATER;
+    grid[row][1] = TILE.WATER;
+    grid[row][MAP_COLS - 1] = TILE.WATER;
+    grid[row][MAP_COLS - 2] = TILE.WATER;
+  }
+
+  // Main cross paths
+  const midCol = Math.floor(MAP_COLS / 2);
+  const midRow = Math.floor(MAP_ROWS / 2);
+  for (let r = 2; r < MAP_ROWS - 2; r++) {
+    grid[r][midCol]     = TILE.PATH;
+    grid[r][midCol - 1] = TILE.PATH;
+  }
+  for (let c = 2; c < MAP_COLS - 2; c++) {
+    grid[midRow][c]     = TILE.PATH;
+    grid[midRow - 1][c] = TILE.PATH;
+  }
+
+  // Scatter some flowers
+  const flowerPositions = [
+    [5,5],[5,34],[34,5],[34,34],
+    [8,15],[15,8],[8,24],[24,8],
+    [31,15],[15,31],[31,24],[24,31],
+  ];
+  flowerPositions.forEach(([r, c]) => { grid[r][c] = TILE.FLOWER; });
+
+  // Tree clusters (corners — kept away from portals)
+  [[4,4],[4,5],[4,6],[5,6],[6,5],[3,5]].forEach(([r,c]) => { grid[r][c] = TILE.TREE_TOP; });
+  [[4,33],[4,34],[4,35],[5,33],[6,34],[3,34]].forEach(([r,c]) => { grid[r][c] = TILE.TREE_TOP; });
+  [[34,4],[34,5],[35,4],[35,5],[33,6],[36,5]].forEach(([r,c]) => { grid[r][c] = TILE.TREE_TOP; });
+  [[34,33],[34,34],[35,33],[35,34],[33,33],[36,34]].forEach(([r,c]) => { grid[r][c] = TILE.TREE_TOP; });
+  // Extra trees along top/bottom edges
+  [[3,12],[3,13],[3,25],[3,26]].forEach(([r,c]) => { grid[r][c] = TILE.TREE_TOP; });
+  [[36,12],[36,13],[36,25],[36,26]].forEach(([r,c]) => { grid[r][c] = TILE.TREE_TOP; });
+
+  // ── Branch paths leading from main cross to each portal ──────────────────
+  // Players need clear roads; without these the map is a featureless grass field.
+
+  // Kitchen (col 10, row 8): horizontal branch west from vertical path
+  for (let c = 9; c <= 20; c++) { grid[8][c] = TILE.PATH; grid[9][c] = TILE.PATH; }
+
+  // Laundry (col 28, row 8): horizontal branch east from vertical path
+  for (let c = 19; c <= 29; c++) { grid[8][c] = TILE.PATH; grid[9][c] = TILE.PATH; }
+
+  // Yard (col 10, row 28): horizontal branch west from vertical path
+  for (let c = 9; c <= 20; c++) { grid[28][c] = TILE.PATH; grid[29][c] = TILE.PATH; }
+
+  // Study (col 28, row 28): horizontal branch east from vertical path
+  for (let c = 19; c <= 29; c++) { grid[28][c] = TILE.PATH; grid[29][c] = TILE.PATH; }
+
+  // Flower markers at each portal destination (visual landmark)
+  [[7,9],[7,10],[10,6],[11,6]].forEach(([r,c]) => {         // Kitchen
+    if (grid[r][c] === TILE.GRASS) grid[r][c] = TILE.FLOWER;
+  });
+  [[7,29],[7,28],[10,33],[11,33]].forEach(([r,c]) => {      // Laundry
+    if (grid[r][c] === TILE.GRASS) grid[r][c] = TILE.FLOWER;
+  });
+  [[30,9],[30,10],[28,6],[27,6]].forEach(([r,c]) => {       // Yard
+    if (grid[r][c] === TILE.GRASS) grid[r][c] = TILE.FLOWER;
+  });
+  [[30,29],[30,28],[28,33],[27,33]].forEach(([r,c]) => {    // Study
+    if (grid[r][c] === TILE.GRASS) grid[r][c] = TILE.FLOWER;
+  });
+
+  return grid;
+}

--- a/frontend/src/game/engine/BootScene.js
+++ b/frontend/src/game/engine/BootScene.js
@@ -1,0 +1,59 @@
+// BootScene: generates all sprites via canvas and passes userId + save data
+// to the main WorldScene.
+
+import Phaser from 'phaser';
+import { generateAllSprites } from '../sprites/SpriteGenerator.js';
+import { loadSave, defaultSave } from '../systems/SaveSystem.js';
+
+export class BootScene extends Phaser.Scene {
+  constructor() {
+    super({ key: 'BootScene' });
+  }
+
+  init(data) {
+    this.userId    = data.userId ?? 'guest';
+    this.userName  = data.userName ?? 'Hero';
+    this.onExit    = data.onExit ?? (() => {});
+    this.onComplete = data.onComplete ?? (() => {});
+  }
+
+  create() {
+    const w = this.scale.width;
+    const h = this.scale.height;
+
+    // Loading screen
+    this.add.rectangle(0, 0, w, h, 0x121212).setOrigin(0);
+    const title = this.add.text(w / 2, h / 2 - 24, 'ChoreQuest', {
+      fontSize: '24px',
+      fontFamily: 'monospace',
+      color: '#fcd860',
+      stroke: '#000000',
+      strokeThickness: 4,
+      resolution: 2,
+    }).setOrigin(0.5);
+
+    const sub = this.add.text(w / 2, h / 2 + 8, 'Loading Adventure Mode...', {
+      fontSize: '10px',
+      fontFamily: 'monospace',
+      color: '#bcbcbc',
+      resolution: 2,
+    }).setOrigin(0.5);
+
+    // Generate all sprites (canvas-based, synchronous)
+    const tileMap = generateAllSprites(this);
+
+    loadSave(this.userId).then((save) => {
+      // Guard: game may have been destroyed by the time this resolves (React StrictMode double-invoke)
+      if (!this.sys?.game || this.sys.game.isDestroyed) return;
+      const gameData = save ?? defaultSave(this.userId);
+      this.scene.start('WorldScene', {
+        userId:    this.userId,
+        userName:  this.userName,
+        gameData,
+        tileMap,
+        onExit:    this.onExit,
+        onComplete: this.onComplete,
+      });
+    });
+  }
+}

--- a/frontend/src/game/engine/GameInstance.js
+++ b/frontend/src/game/engine/GameInstance.js
@@ -1,0 +1,54 @@
+// Creates and destroys the Phaser game instance.
+// Called from the React AdventureMode page component.
+
+import Phaser from 'phaser';
+import { BootScene }  from './BootScene.js';
+import { WorldScene } from './WorldScene.js';
+
+export function createGame(containerId, options = {}) {
+  const { userId, userName, headerH = 34, onExit, onComplete } = options;
+
+  const container = document.getElementById(containerId);
+  const availW = container ? container.clientWidth  : window.innerWidth;
+  const availH = container ? container.clientHeight : (window.innerHeight - headerH);
+
+  const gameW = Math.min(availW, 800);
+  const gameH = Math.min(availH, 600);
+
+  const config = {
+    type: Phaser.AUTO,
+    parent: containerId,
+    width:  gameW,
+    height: gameH,
+    backgroundColor: '#121212',
+    pixelArt: true,
+    antialias: false,
+    roundPixels: true,
+    physics: {
+      default: 'arcade',
+      arcade: { gravity: { y: 0 }, debug: false },
+    },
+    scene: [BootScene, WorldScene],
+    scale: {
+      mode: Phaser.Scale.FIT,
+      autoCenter: Phaser.Scale.CENTER_BOTH,
+      width:  gameW,
+      height: gameH,
+    },
+    input: { touch: true },
+  };
+
+  const game = new Phaser.Game(config);
+
+  game.events.once('ready', () => {
+    game.scene.start('BootScene', { userId, userName, onExit, onComplete });
+  });
+
+  return game;
+}
+
+export function destroyGame(game) {
+  if (game && !game.isDestroyed) {
+    game.destroy(true);
+  }
+}

--- a/frontend/src/game/engine/WorldScene.js
+++ b/frontend/src/game/engine/WorldScene.js
@@ -1,0 +1,393 @@
+// WorldScene: the main overworld. Player walks, fights, and enters portals.
+
+import Phaser from 'phaser';
+import { buildWorldTilemap }     from '../maps/WorldMap.js';
+import { createPlayer, updatePlayer, PLAYER_SPEED } from '../entities/Player.js';
+import { createEnemyAnimations, spawnEnemy, updateEnemy } from '../entities/Enemy.js';
+import { PortalManager }         from '../chore-portals/PortalManager.js';
+import { BattleSystem }          from '../systems/BattleSystem.js';
+import { HUD }                   from '../ui/HUD.js';
+import { writeSave }             from '../systems/SaveSystem.js';
+import { SoundSystem }          from '../systems/SoundSystem.js';
+
+const HUD_DEPTH = 100;
+import { PORTAL_ZONES, ENEMY_ZONES, TILE_SIZE, levelFromXp } from '../data/WorldData.js';
+
+const SAVE_INTERVAL = 15000; // ms
+
+export class WorldScene extends Phaser.Scene {
+  constructor() {
+    super({ key: 'WorldScene' });
+  }
+
+  init(data) {
+    this.userId    = data.userId;
+    this.userName  = data.userName;
+    this.gameData  = { ...data.gameData };
+    this.tileMap   = data.tileMap;
+    this.onExit    = data.onExit    ?? (() => {});
+    this.onComplete = data.onComplete ?? (() => {});
+
+    this._portalCooldown = 0;
+    this._saveTick       = 0;
+    this._paused         = false;
+    this._lastLevel      = levelFromXp(data.gameData?.xp ?? 0);
+  }
+
+  create() {
+    // ── Tilemap ────────────────────────────────────────────────────────
+    const { map, layer } = buildWorldTilemap(this);
+    this.worldLayer = layer;
+
+    // ── Player ─────────────────────────────────────────────────────────
+    this.player = createPlayer(
+      this,
+      this.gameData.playerX,
+      this.gameData.playerY,
+    );
+    this.cameras.main.startFollow(this.player, true, 0.15, 0.15);
+
+    // Collision: player <-> world tiles
+    this.physics.add.collider(this.player, layer);
+
+    // ── Enemies ────────────────────────────────────────────────────────
+    createEnemyAnimations(this);
+    this.enemies = this.physics.add.group();
+    ENEMY_ZONES.forEach((zone) => {
+      for (let i = 0; i < zone.count; i++) {
+        const jx = zone.x * TILE_SIZE + (Math.random() - 0.5) * TILE_SIZE * 2;
+        const jy = zone.y * TILE_SIZE + (Math.random() - 0.5) * TILE_SIZE * 2;
+        const enemy = spawnEnemy(this, zone.type, jx, jy);
+        this.enemies.add(enemy);
+        this.physics.add.collider(enemy, layer);
+      }
+    });
+
+    // Enemy<->player contact
+    this.physics.add.overlap(this.player, this.enemies, (player, enemy) => {
+      this.battle.enemyContactDamage(player, enemy);
+    });
+
+    // ── Portals ────────────────────────────────────────────────────────
+    this.portalMgr = new PortalManager(this);
+    this.portalMgr.addOverlap(this.player);
+    Object.entries(this.gameData.portalRestoreLevels ?? {}).forEach(([id, lvl]) => {
+      this.portalMgr.setRestoreLevel(id, lvl);
+    });
+
+    // ── Sound system ────────────────────────────────────────────────────
+    this.sfx = new SoundSystem(this);
+    this.sfx.startBGM();
+
+    // ── Battle system ──────────────────────────────────────────────────
+    this.battle = new BattleSystem(this);
+    this.events.on('enemyHurt', ({ enemy, damage }) => {
+      // Show damage number over every hit — makes attacks feel responsive
+      this.hud.showFloatingText(enemy.x, enemy.y - 16, `-${damage}`, '#ff4444');
+    });
+
+    this.events.on('enemyDefeated', ({ enemy, xpDrop, coinDrop }) => {
+      this.gameData.xp    += xpDrop;
+      this.gameData.coins += coinDrop;
+      this.hud.showFloatingText(enemy.x, enemy.y, `+${xpDrop} XP`, '#58d854');
+      this.hud.showFloatingText(enemy.x, enemy.y + 14, `+${coinDrop}¢`, '#fcd860');
+      this.sfx.playEnemyDefeat();
+      if (coinDrop > 0) this.time.delayedCall(280, () => this.sfx.playCoinPickup());
+    });
+    this.events.on('playerHurt', ({ damage }) => {
+      this.gameData.hp = Math.max(0, this.gameData.hp - damage);
+      this.sfx.playPlayerHurt();
+      if (this.gameData.hp <= 0) this._handlePlayerDeath();
+    });
+
+    // ── Portal entry ───────────────────────────────────────────────────
+    this.events.on('portalEnter', (zoneData) => {
+      const now = Date.now();
+      if (now - this._portalCooldown < 2000) return;
+      this._portalCooldown = now;
+      this.sfx.playPortalEnter();
+      this.onComplete({ type: 'portalEnter', zone: zoneData, gameData: this.gameData });
+    });
+
+    // ── HUD ────────────────────────────────────────────────────────────
+    this.hud = new HUD(this);
+
+    // ── Keyboard ──────────────────────────────────────────────────────
+    this.cursors = this.input.keyboard.createCursorKeys();
+    this.wasd    = this.input.keyboard.addKeys({
+      up:    Phaser.Input.Keyboard.KeyCodes.W,
+      down:  Phaser.Input.Keyboard.KeyCodes.S,
+      left:  Phaser.Input.Keyboard.KeyCodes.A,
+      right: Phaser.Input.Keyboard.KeyCodes.D,
+    });
+    this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+    this.escKey   = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
+
+    // ── Pause overlay (ESC) ───────────────────────────────────────────
+    this.escKey.on('down', () => this._togglePause());
+
+    // ── World name banner ─────────────────────────────────────────────
+    const banner = this.add.text(
+      this.scale.width / 2, 20,
+      'Home Realm — Broken Village',
+      { fontSize: '10px', fontFamily: 'monospace', color: '#fcd860',
+        stroke: '#000000', strokeThickness: 3, resolution: 2 }
+    ).setScrollFactor(0).setDepth(50).setOrigin(0.5);
+    this.tweens.add({ targets: banner, alpha: 0, delay: 3000, duration: 1000 });
+
+    // ── Exit button ───────────────────────────────────────────────────
+    const exitBtn = this.add.text(
+      this.scale.width - 8, 8, '[EXIT]',
+      { fontSize: '8px', fontFamily: 'monospace', color: '#ff6644',
+        stroke: '#000', strokeThickness: 2, resolution: 2 }
+    ).setScrollFactor(0).setDepth(HUD_DEPTH + 5).setOrigin(1, 0).setInteractive({ useHandCursor: true });
+    exitBtn.on('pointerdown', () => this._exitGame());
+
+    // ── Tutorial (first visit only) ───────────────────────────────────
+    if (!this.gameData.tutorialSeen) {
+      this.time.delayedCall(400, () => this._showTutorial());
+    }
+  }
+
+  update(time, delta) {
+    if (this._paused) return;
+
+    // Build combined input (keyboard + touch)
+    const touch = this.hud?.touchKeys ?? {};
+    const cursors = {
+      left:  { isDown: this.cursors.left.isDown  || (touch.left?.isDown  ?? false) },
+      right: { isDown: this.cursors.right.isDown || (touch.right?.isDown ?? false) },
+      up:    { isDown: this.cursors.up.isDown    || (touch.up?.isDown    ?? false) },
+      down:  { isDown: this.cursors.down.isDown  || (touch.down?.isDown  ?? false) },
+    };
+
+    updatePlayer(this.player, cursors, this.wasd);
+
+    // Attack on SPACE or touch attack button
+    if (
+      Phaser.Input.Keyboard.JustDown(this.spaceKey) ||
+      (touch.attack?.isDown)
+    ) {
+      this.battle.playerAttack(this.player.weapon, this.enemies, this.player);
+      this._spawnAttackVfx();
+      this.sfx.playAttack();
+    }
+
+    // Level-up detection
+    const curLevel = levelFromXp(this.gameData.xp);
+    if (curLevel > this._lastLevel) {
+      this._lastLevel = curLevel;
+      this.sfx.playLevelUp();
+    }
+
+    // Update enemies
+    this.enemies.getChildren().forEach((e) => updateEnemy(e, this.player, delta));
+
+    // Save player position to gameData continuously
+    this.gameData.playerX = this.player.x;
+    this.gameData.playerY = this.player.y;
+
+    // Periodic save
+    this._saveTick += delta;
+    if (this._saveTick >= SAVE_INTERVAL) {
+      this._saveTick = 0;
+      writeSave({ ...this.gameData, userId: this.userId });
+    }
+
+    // Update HUD
+    this.hud.update(this.gameData);
+  }
+
+  _spawnAttackVfx() {
+    // A wider, brighter sweep that makes it obvious you swung
+    const offsets = { down: [0, 32], up: [0, -32], left: [-32, 0], right: [32, 0] };
+    const [ox, oy] = offsets[this.player.facing] ?? [0, 32];
+    const isHoriz  = (this.player.facing === 'left' || this.player.facing === 'right');
+
+    // Sweep rectangle — elongated in the perpendicular direction
+    const vfx = this.add.rectangle(
+      this.player.x + ox, this.player.y + oy,
+      isHoriz ? 24 : 48,   // width
+      isHoriz ? 48 : 24,   // height
+      0xffffff, 0.85
+    ).setDepth(12);
+
+    this.tweens.add({
+      targets: vfx,
+      alpha: 0,
+      scaleX: 1.8,
+      scaleY: 1.8,
+      duration: 180,
+      ease: 'Power2',
+      onComplete: () => vfx.destroy(),
+    });
+  }
+
+  _handlePlayerDeath() {
+    this.player.isAlive = false;
+    this.player.body.setVelocity(0, 0);
+
+    const w = this.scale.width;
+    const h = this.scale.height;
+    this.add.rectangle(w / 2, h / 2, w, h, 0x000000, 0.6)
+      .setScrollFactor(0).setDepth(200);
+    this.add.text(w / 2, h / 2 - 16, 'You Fainted!', {
+      fontSize: '20px', fontFamily: 'monospace', color: '#ff4444',
+      stroke: '#000', strokeThickness: 4, resolution: 2,
+    }).setScrollFactor(0).setDepth(201).setOrigin(0.5);
+
+    this.time.delayedCall(2500, () => {
+      // Respawn: restore 3 HP
+      this.gameData.hp = Math.min(3, this.gameData.maxHp);
+      this.gameData.playerX = 640;
+      this.gameData.playerY = 640;
+      this.scene.restart({
+        userId: this.userId, userName: this.userName,
+        gameData: this.gameData, tileMap: this.tileMap,
+        onExit: this.onExit, onComplete: this.onComplete,
+      });
+    });
+  }
+
+  _togglePause() {
+    this._paused = !this._paused;
+    if (this._paused) {
+      this.physics.pause();
+      this._showPauseMenu();
+    } else {
+      this.physics.resume();
+      if (this._pauseOverlay) {
+        this._pauseOverlay.destroy();
+        this._pauseOverlay = null;
+      }
+    }
+  }
+
+  _showPauseMenu() {
+    const w = this.scale.width;
+    const h = this.scale.height;
+    const container = this.add.container(0, 0).setScrollFactor(0).setDepth(300);
+
+    const bg = this.add.rectangle(w / 2, h / 2, 200, 160, 0x000000, 0.85);
+    const title = this.add.text(w / 2, h / 2 - 55, '— PAUSED —', {
+      fontSize: '14px', fontFamily: 'monospace', color: '#fcd860',
+      stroke: '#000', strokeThickness: 3, resolution: 2,
+    }).setOrigin(0.5);
+
+    const resumeBtn = this._makePauseBtn(w / 2, h / 2 - 20, 'Resume', () => this._togglePause());
+    const exitBtn   = this._makePauseBtn(w / 2, h / 2 + 20, 'Exit Adventure', () => this._exitGame());
+
+    container.add([bg, title, resumeBtn.bg, resumeBtn.label, exitBtn.bg, exitBtn.label]);
+    this._pauseOverlay = container;
+  }
+
+  _makePauseBtn(x, y, text, cb) {
+    const bg = this.add.rectangle(x, y, 140, 24, 0x2a2a2a, 1)
+      .setInteractive({ useHandCursor: true })
+      .on('pointerdown', cb)
+      .on('pointerover',  () => bg.setFillStyle(0x444444))
+      .on('pointerout',   () => bg.setFillStyle(0x2a2a2a));
+    const label = this.add.text(x, y, text, {
+      fontSize: '10px', fontFamily: 'monospace', color: '#ffffff', resolution: 2,
+    }).setOrigin(0.5);
+    return { bg, label };
+  }
+
+  _showTutorial() {
+    this._paused = true;
+    this.physics.pause();
+
+    const w = this.scale.width;
+    const h = this.scale.height;
+    const cx = w / 2;
+    const cy = h / 2;
+
+    const panelW = Math.min(w - 32, 340);
+    const panelH = 310;
+
+    const container = this.add.container(0, 0).setScrollFactor(0).setDepth(400);
+
+    // ── Background layers (added first = rendered behind) ─────────────
+    const dim   = this.add.rectangle(cx, cy, w, h, 0x000000, 0.75);
+    const panel = this.add.rectangle(cx, cy, panelW, panelH, 0x1a1a2e, 1)
+                    .setStrokeStyle(2, 0xfcd860);
+    container.add([dim, panel]);
+
+    // ── Title + divider ───────────────────────────────────────────────
+    const title = this.add.text(cx, cy - panelH / 2 + 22, '-- HOW TO PLAY --', {
+      fontSize: '11px', fontFamily: 'monospace', color: '#fcd860',
+      stroke: '#000', strokeThickness: 3, resolution: 2,
+    }).setOrigin(0.5);
+    const divLine = this.add.rectangle(cx, cy - panelH / 2 + 38, panelW - 24, 1, 0x3a3a5a);
+    container.add([title, divLine]);
+
+    // ── Control rows ─────────────────────────────────────────────────
+    // [bullet, label, description]
+    const rows = [
+      ['>>', 'MOVE',    'Arrow keys  or  W  A  S  D'],
+      ['>>',  'ATTACK',  'SPACE  (broom swing)'],
+      ['>>',  'PORTALS', 'Walk into glowing orbs\nto open chore quests'],
+      ['>>',  'ENEMIES', 'Attack critters for XP & coins'],
+      ['>>',  'PAUSE',   'ESC  key'],
+    ];
+
+    const rowStartY = cy - panelH / 2 + 60;
+    const rowStep   = 44;
+    const lx = cx - panelW / 2 + 18; // left edge of text
+
+    rows.forEach(([, label, desc], i) => {
+      const ry = rowStartY + i * rowStep;
+
+      const bullet = this.add.text(lx, ry, '>>', {
+        fontSize: '8px', fontFamily: 'monospace', color: '#fcd860',
+        stroke: '#000', strokeThickness: 2, resolution: 2,
+      }).setOrigin(0, 0.5);
+
+      const labelTxt = this.add.text(lx + 20, ry, label, {
+        fontSize: '9px', fontFamily: 'monospace', color: '#ffffff',
+        stroke: '#000', strokeThickness: 2, resolution: 2,
+      }).setOrigin(0, 0.5);
+
+      const descTxt = this.add.text(lx + 20, ry + 14, desc, {
+        fontSize: '7px', fontFamily: 'monospace', color: '#aaaaaa',
+        stroke: '#000', strokeThickness: 2, resolution: 2, lineSpacing: 3,
+      }).setOrigin(0, 0);
+
+      container.add([bullet, labelTxt, descTxt]);
+    });
+
+    // ── "Let's go!" button ────────────────────────────────────────────
+    const btnY  = cy + panelH / 2 - 26;
+    const btnBg = this.add.rectangle(cx, btnY, 150, 28, 0xfcd860)
+      .setInteractive({ useHandCursor: true });
+    const btnTxt = this.add.text(cx, btnY, "Let's go!  (or press any key)", {
+      fontSize: '8px', fontFamily: 'monospace', color: '#1a1a2e',
+      resolution: 2,
+    }).setOrigin(0.5);
+    container.add([btnBg, btnTxt]);
+
+    // ── Dismiss logic ─────────────────────────────────────────────────
+    const dismiss = () => {
+      container.destroy();
+      this._paused = false;
+      this.physics.resume();
+      this.gameData.tutorialSeen = true;
+      writeSave({ ...this.gameData, userId: this.userId });
+      this.input.keyboard.off('keydown', dismiss);
+    };
+
+    btnBg.on('pointerdown', dismiss);
+    btnBg.on('pointerover',  () => btnBg.setFillStyle(0xffe080));
+    btnBg.on('pointerout',   () => btnBg.setFillStyle(0xfcd860));
+    this.input.keyboard.once('keydown', dismiss);
+  }
+
+  _exitGame() {
+    writeSave({ ...this.gameData, userId: this.userId });
+    this.onExit();
+  }
+
+  shutdown() {
+    this.sfx?.destroy();
+  }
+}

--- a/frontend/src/game/engine/WorldScene.js
+++ b/frontend/src/game/engine/WorldScene.js
@@ -8,10 +8,10 @@ import { PortalManager }         from '../chore-portals/PortalManager.js';
 import { BattleSystem }          from '../systems/BattleSystem.js';
 import { HUD }                   from '../ui/HUD.js';
 import { writeSave }             from '../systems/SaveSystem.js';
-import { SoundSystem }          from '../systems/SoundSystem.js';
+import { SoundSystem }           from '../systems/SoundSystem.js';
+import { PORTAL_ZONES, ENEMY_ZONES, TILE_SIZE, levelFromXp } from '../data/WorldData.js';
 
 const HUD_DEPTH = 100;
-import { PORTAL_ZONES, ENEMY_ZONES, TILE_SIZE, levelFromXp } from '../data/WorldData.js';
 
 const SAVE_INTERVAL = 15000; // ms
 

--- a/frontend/src/game/engine/WorldScene.js
+++ b/frontend/src/game/engine/WorldScene.js
@@ -79,6 +79,9 @@ export class WorldScene extends Phaser.Scene {
     this.sfx = new SoundSystem(this);
     this.sfx.startBGM();
 
+    // ── HUD — must be created before event listeners that call this.hud ─
+    this.hud = new HUD(this);
+
     // ── Battle system ──────────────────────────────────────────────────
     this.battle = new BattleSystem(this);
     this.events.on('enemyHurt', ({ enemy, damage }) => {
@@ -108,9 +111,6 @@ export class WorldScene extends Phaser.Scene {
       this.sfx.playPortalEnter();
       this.onComplete({ type: 'portalEnter', zone: zoneData, gameData: this.gameData });
     });
-
-    // ── HUD ────────────────────────────────────────────────────────────
-    this.hud = new HUD(this);
 
     // ── Keyboard ──────────────────────────────────────────────────────
     this.cursors = this.input.keyboard.createCursorKeys();

--- a/frontend/src/game/entities/Enemy.js
+++ b/frontend/src/game/entities/Enemy.js
@@ -1,0 +1,74 @@
+// Enemy entity factory — creates animated enemies that wander and chase the player.
+
+import { ENEMY_STATS } from '../data/WorldData.js';
+
+export function createEnemyAnimations(scene) {
+  const keys = Object.keys(ENEMY_STATS);
+  keys.forEach((key) => {
+    const texKey = `enemy_${key}`;
+    if (!scene.textures.exists(texKey)) return;
+    const animKey = `${texKey}_walk`;
+    if (scene.anims.exists(animKey)) return;
+    scene.anims.create({
+      key: animKey,
+      frames: scene.anims.generateFrameNumbers(texKey, { start: 0, end: 1 }),
+      frameRate: 3,
+      repeat: -1,
+    });
+  });
+}
+
+export function spawnEnemy(scene, type, x, y) {
+  const stats  = ENEMY_STATS[type] ?? ENEMY_STATS.dust_bunny;
+  const texKey = `enemy_${type}`;
+
+  const enemy    = scene.physics.add.sprite(x, y, texKey);
+  enemy.enemyType = type;
+  enemy.hp       = stats.hp;
+  enemy.maxHp    = stats.hp;
+  enemy.xpDrop   = stats.xp;
+  enemy.coinDrop = stats.coins;
+  enemy.speed    = stats.speed;
+  enemy.label    = stats.name;
+  enemy.setDepth(9);
+  enemy.setCollideWorldBounds(true);
+
+  const animKey = `enemy_${type}_walk`;
+  if (scene.anims.exists(animKey)) enemy.play(animKey);
+
+  // Wander state
+  enemy.wanderTimer  = 0;
+  enemy.wanderAngle  = Math.random() * Math.PI * 2;
+  enemy.chasing      = false;
+
+  return enemy;
+}
+
+export function updateEnemy(enemy, playerSprite, delta) {
+  if (!enemy.active) return;
+
+  const dx   = playerSprite.x - enemy.x;
+  const dy   = playerSprite.y - enemy.y;
+  const dist = Math.sqrt(dx * dx + dy * dy);
+
+  // Chase if within 120 px
+  if (dist < 120) {
+    enemy.chasing = true;
+    const nx  = dx / dist;
+    const ny  = dy / dist;
+    enemy.body.setVelocity(nx * enemy.speed, ny * enemy.speed);
+    return;
+  }
+
+  enemy.chasing = false;
+  // Wander
+  enemy.wanderTimer -= delta;
+  if (enemy.wanderTimer <= 0) {
+    enemy.wanderTimer  = 1500 + Math.random() * 2000;
+    enemy.wanderAngle  = Math.random() * Math.PI * 2;
+  }
+
+  const wx = Math.cos(enemy.wanderAngle) * (enemy.speed * 0.5);
+  const wy = Math.sin(enemy.wanderAngle) * (enemy.speed * 0.5);
+  enemy.body.setVelocity(wx, wy);
+}

--- a/frontend/src/game/entities/Player.js
+++ b/frontend/src/game/entities/Player.js
@@ -1,0 +1,77 @@
+// Player entity — Phaser Physics Sprite with 4-direction walk animation.
+// Animation key convention: player_down/up/left/right (3 frames each).
+
+export const PLAYER_SPEED = 120;
+
+export function createPlayerAnimations(scene) {
+  const anims = scene.anims;
+  if (anims.exists('player_down')) return;
+
+  // Frame layout in sheet: 12 frames total (dir*3 + walkFrame)
+  // dir: 0=down, 1=left, 2=right, 3=up
+  const dirMap = { down: 0, left: 1, right: 2, up: 3 };
+  Object.entries(dirMap).forEach(([dir, dirIdx]) => {
+    const start = dirIdx * 3;
+    anims.create({
+      key: `player_${dir}`,
+      frames: anims.generateFrameNumbers('player', { start, end: start + 2 }),
+      frameRate: 6,
+      repeat: -1,
+    });
+    anims.create({
+      key: `player_${dir}_idle`,
+      frames: anims.generateFrameNumbers('player', { start, end: start }),
+      frameRate: 1,
+      repeat: -1,
+    });
+  });
+}
+
+export function createPlayer(scene, x, y) {
+  createPlayerAnimations(scene);
+
+  const player = scene.physics.add.sprite(x, y, 'player');
+  player.setCollideWorldBounds(true);
+  player.setDepth(10);
+  player.play('player_down_idle');
+
+  // State
+  player.facing  = 'down';
+  player.weapon  = 'broom';
+  player.isAlive = true;
+
+  return player;
+}
+
+export function updatePlayer(player, cursors, wasd, speed = PLAYER_SPEED) {
+  if (!player.isAlive) return;
+
+  const body = player.body;
+  let vx = 0;
+  let vy = 0;
+
+  const left  = cursors.left.isDown  || wasd.left.isDown;
+  const right = cursors.right.isDown || wasd.right.isDown;
+  const up    = cursors.up.isDown    || wasd.up.isDown;
+  const down  = cursors.down.isDown  || wasd.down.isDown;
+
+  if (left)  vx -= speed;
+  if (right) vx += speed;
+  if (up)    vy -= speed;
+  if (down)  vy += speed;
+
+  // Normalize diagonal
+  if (vx !== 0 && vy !== 0) {
+    vx *= 0.707;
+    vy *= 0.707;
+  }
+
+  body.setVelocity(vx, vy);
+
+  // Direction + animation
+  if (vx < 0)      { player.facing = 'left';  player.play('player_left',  true); }
+  else if (vx > 0) { player.facing = 'right'; player.play('player_right', true); }
+  else if (vy < 0) { player.facing = 'up';    player.play('player_up',    true); }
+  else if (vy > 0) { player.facing = 'down';  player.play('player_down',  true); }
+  else             { player.play(`player_${player.facing}_idle`, true); }
+}

--- a/frontend/src/game/maps/WorldMap.js
+++ b/frontend/src/game/maps/WorldMap.js
@@ -1,0 +1,33 @@
+// Builds the world tilemap from the procedural grid in WorldData.
+
+import { buildBaseMap, TILE, MAP_COLS, MAP_ROWS, TILE_SIZE } from '../data/WorldData.js';
+
+const TILE_NAMES = ['grass','dirt','water','path','tree_top','tree_bot','wall','flower'];
+
+export function buildWorldTilemap(scene) {
+  const grid = buildBaseMap();
+
+  // Convert enum grid to Phaser tilemap data (1-indexed, 0=empty)
+  const mapData = grid.map(row => row.map(t => t + 1));
+
+  const map = scene.make.tilemap({
+    data:       mapData,
+    tileWidth:  TILE_SIZE,
+    tileHeight: TILE_SIZE,
+    width:      MAP_COLS,
+    height:     MAP_ROWS,
+  });
+
+  const tiles = map.addTilesetImage('tileset', 'tileset', TILE_SIZE, TILE_SIZE, 0, 0);
+  const layer = map.createLayer(0, tiles, 0, 0);
+  layer.setDepth(0);
+
+  // Collision tiles: water (3), tree_top (5), wall (7) — 1-indexed
+  map.setCollision([TILE.WATER + 1, TILE.TREE_TOP + 1, TILE.WALL + 1]);
+
+  // World bounds
+  scene.physics.world.setBounds(0, 0, MAP_COLS * TILE_SIZE, MAP_ROWS * TILE_SIZE);
+  scene.cameras.main.setBounds(0, 0, MAP_COLS * TILE_SIZE, MAP_ROWS * TILE_SIZE);
+
+  return { map, layer };
+}

--- a/frontend/src/game/sprites/SpriteGenerator.js
+++ b/frontend/src/game/sprites/SpriteGenerator.js
@@ -1,0 +1,785 @@
+// Procedural pixel-art sprite generator using canvas.
+// All sprites are generated at runtime — no external image files required.
+
+const NES = {
+  black:      '#000000',
+  white:      '#fcfcfc',
+  lgray:      '#bcbcbc',
+  mgray:      '#7c7c7c',
+  dgray:      '#3c3c3c',
+  red:        '#d82800',
+  lred:       '#f87858',
+  orange:     '#fc7820',
+  lorange:    '#fca044',
+  yellow:     '#f8b800',
+  lyellow:    '#fcd860',
+  green:      '#009c48',
+  lgreen:     '#58d854',
+  teal:       '#008888',
+  lteal:      '#58d8a8',
+  blue:       '#0028f8',
+  lblue:      '#6888fc',
+  sky:        '#3cbcfc',
+  lsky:       '#a4e4fc',
+  purple:     '#6844fc',
+  lpurple:    '#b0a4f8',
+  brown:      '#503000',
+  lbrown:     '#c07840',
+  skin:       '#fcd8a8',
+  darkskin:   '#f0a060',
+  transparent: null,
+};
+
+export function createCanvas(w, h) {
+  const c = document.createElement('canvas');
+  c.width = w;
+  c.height = h;
+  return c;
+}
+
+// Upload a canvas directly as a Phaser CanvasTexture.
+// This avoids the async HTMLImageElement loading race that causes
+// "INVALID_VALUE: texImage2D: no image" in headless/SwiftShader WebGL.
+function addCanvasTexture(scene, key, canvas) {
+  if (scene.textures.exists(key)) scene.textures.remove(key);
+  const tex = scene.textures.createCanvas(key, canvas.width, canvas.height);
+  tex.context.drawImage(canvas, 0, 0);
+  tex.refresh();
+  return tex;
+}
+
+// Same as above but also registers sprite-sheet frames by index.
+function addCanvasSpriteSheet(scene, key, canvas, frameWidth, frameHeight) {
+  const tex = addCanvasTexture(scene, key, canvas);
+  const cols = Math.floor(canvas.width  / frameWidth);
+  const rows = Math.floor(canvas.height / frameHeight);
+  for (let i = 0; i < cols * rows; i++) {
+    tex.add(i, 0, (i % cols) * frameWidth, Math.floor(i / cols) * frameHeight, frameWidth, frameHeight);
+  }
+  return tex;
+}
+
+function drawPixel(ctx, x, y, color, scale = 1) {
+  if (!color) return;
+  ctx.fillStyle = color;
+  ctx.fillRect(x * scale, y * scale, scale, scale);
+}
+
+function drawGrid(ctx, grid, palette, scale = 1) {
+  grid.forEach((row, y) =>
+    [...row].forEach((code, x) => {
+      const color = palette[code];
+      if (color) drawPixel(ctx, x, y, color, scale);
+    })
+  );
+}
+
+// ─── TILESET (16×16 each, 4 cols wide) ────────────────────────────────────────
+
+const TILE_SCALE = 2; // render at 32×32 display
+const TILE_SRC   = 16;
+const TILES_PER_ROW = 8;
+
+const TILE_DEFS = {
+  grass: {
+    // Cleaner lawn — sparse darker flecks so it reads as solid green
+    grid: [
+      'gggggggggggggggg',
+      'gggggggggggggggg',
+      'ggGggggggggggggg',
+      'gggggggggggggggg',
+      'ggggggggGggggggg',
+      'gggggggggggggggg',
+      'ggggGggggggggggg',
+      'gggggggggggggggg',
+      'gggggggggggggggg',
+      'gggGgggggggggggg',
+      'gggggggggggggggg',
+      'ggggggGggggggggg',
+      'gggggggggggggggg',
+      'ggggggggggGggggg',
+      'gggggggggggggggg',
+      'ggGggggggggggggg',
+    ],
+    p: { g: NES.lgreen, G: NES.green },
+  },
+  dirt: {
+    grid: [
+      'dddddddddddddddd',
+      'dddDdddddDdddddd',
+      'ddddddDddddddDdd',
+      'ddDddddddddddddd',
+      'ddddddddDdddddDd',
+      'ddddDddddddddddd',
+      'dddddddddDdddddd',
+      'ddDddddddddDdddd',
+      'dddddddddddddddd',
+      'dddDdddDdddddddd',
+      'ddddddddddDddddd',
+      'ddddDdddddddddDd',
+      'ddddddDddddddddd',
+      'ddDdddddddDddddd',
+      'dddddddddddddddd',
+      'ddddddDddddddDdd',
+    ],
+    p: { d: NES.lbrown, D: NES.brown },
+  },
+  water: {
+    // Deeper blue — clear contrast from the green land
+    grid: [
+      'bbbbwwwbbbbbwwwb',
+      'bwwwbbbbbbwwbbbb',
+      'bbbbbbwwwbbbbbww',
+      'wwwbbbbbbbbwwbbb',
+      'bbbbwwwbbbbbwwwb',
+      'bwwwbbbbbbwwbbbb',
+      'bbbbbbwwwbbbbbww',
+      'wwwbbbbbbbbwwbbb',
+      'bbbbwwwbbbbbwwwb',
+      'bwwwbbbbbbwwbbbb',
+      'bbbbbbwwwbbbbbww',
+      'wwwbbbbbbbbwwbbb',
+      'bbbbwwwbbbbbwwwb',
+      'bwwwbbbbbbwwbbbb',
+      'bbbbbbwwwbbbbbww',
+      'wwwbbbbbbbbwwbbb',
+    ],
+    p: { b: NES.blue, w: NES.sky },
+  },
+  path: {
+    // Stone/sandy path — light gray-tan, clearly distinct from green grass
+    grid: [
+      'pppppppppppppppp',
+      'pPppppppPppppppp',
+      'ppppppppppppppPp',
+      'pppPpppppppppppp',
+      'pppppppppPpppppp',
+      'ppppPppppppppppp',
+      'pppppppppppppppp',
+      'pPpppppppppPpppp',
+      'pppppppppppppppp',
+      'ppppPpppPppppppp',
+      'pppppppppppppppp',
+      'pppppppppppPpppp',
+      'ppppPppppppppppp',
+      'pppppppppppppppp',
+      'ppppppppPppppppp',
+      'ppPppppppppppppp',
+    ],
+    p: { p: NES.lgray, P: NES.white },
+  },
+  tree_top: {
+    // '.' is mapped to grass so no transparent black corners appear
+    grid: [
+      'ggggGGGGGGGGgggg',
+      'gggGGGGGGGGGGggg',
+      'ggGGGGGGGGGGGGGg',
+      'gGGGGtGGGGGGGGGg',
+      'GGGGGGGGtGGGGGGG',
+      'GGGtGGGGGGGGGGGG',
+      'GGGGGGGGGGtGGGGG',
+      'GGGGtGGGGGGGGGGG',
+      'GGGGGGGGGGGGtGGG',
+      'GGGGGGtGGGGGGGGG',
+      'gGGGGGGGGGGGtGGg',
+      'ggGGGGGGGGGGGGgg',
+      'gggGGGGGGGGGGggg',
+      'ggggGGGGGGGGgggg',
+      'gggggBBBBBBggggg',
+      'ggggggBBBBgggggg',
+    ],
+    p: { G: NES.lgreen, t: NES.green, B: NES.brown, g: NES.lgreen },
+  },
+  tree_bot: {
+    // grass fill so trunk blends into the map
+    grid: [
+      'ggggggBBBBgggggg',
+      'ggggggBBBBgggggg',
+      'ggggbbbbbbbbgggg',
+      'ggggbbbbbbbbgggg',
+      'ggggbbbbbbbbgggg',
+      'ggggbbbbbbbbgggg',
+      'ggggggbbbbgggggg',
+      'ggggggbbbbgggggg',
+      'gggggbbbbbbbgggg',
+      'gggggbbbbbbbgggg',
+      'gggbbbbbbbbbbggg',
+      'gggbbbbbbbbbbggg',
+      'gggbbbbbbbbbbggg',
+      'gggbbbbbbbbbbggg',
+      'gggggggggggggggg',
+      'gggggggggggggggg',
+    ],
+    p: { B: NES.brown, b: NES.lbrown, g: NES.lgreen },
+  },
+  wall: {
+    grid: [
+      'SSSSSSSSSSSSSSSS',
+      'SsssSsssSsssSsss',
+      'SsssSsssSsssSsss',
+      'SSSSSSSSSSSSSSSS',
+      'sSSSSSSSSSSSSSSs',
+      'SsssSsssSsssSsss',
+      'SsssSsssSsssSsss',
+      'SSSSSSSSSSSSSSSS',
+      'SsssSsssSsssSsss',
+      'SsssSsssSsssSsss',
+      'SSSSSSSSSSSSSSSS',
+      'sSSSSSSSSSSSSSSs',
+      'SsssSsssSsssSsss',
+      'SsssSsssSsssSsss',
+      'SSSSSSSSSSSSSSSS',
+      'SSSSSSSSSSSSSSSS',
+    ],
+    p: { S: NES.mgray, s: NES.lgray },
+  },
+  flower: {
+    grid: [
+      'gggggggggggggggg',
+      'gggggggggggggggg',
+      'ggGgggggggGggggg',
+      'gGrGggggGrGgggGG',
+      'ggGggggggGgggGgG',
+      'ggggggggggggGGgg',
+      'ggggGGgggggggGgg',
+      'gggGrGggggggggg',
+      'ggggGGgggGGggggg',
+      'ggggggggGrGggggg',
+      'ggggggggGGgggGGg',
+      'gggGGgggggggGrGg',
+      'ggGrGgggggggGGgg',
+      'gggGGgggggggggg',
+      'gggggggggggggggg',
+      'gggggggggggggggg',
+    ],
+    p: { g: NES.lgreen, G: NES.green, r: NES.red },
+  },
+};
+
+export function generateTileset(scene) {
+  const cols = TILES_PER_ROW;
+  const keys = Object.keys(TILE_DEFS);
+  const rows = Math.ceil(keys.length / cols);
+  const W = cols * TILE_SRC * TILE_SCALE;
+  const H = rows * TILE_SRC * TILE_SCALE;
+
+  const c = createCanvas(W, H);
+  const ctx = c.getContext('2d');
+
+  keys.forEach((key, i) => {
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    const ox = col * TILE_SRC * TILE_SCALE;
+    const oy = row * TILE_SRC * TILE_SCALE;
+    const def = TILE_DEFS[key];
+    const subCtx = c.getContext('2d');
+    subCtx.save();
+    subCtx.translate(ox, oy);
+    drawGrid(subCtx, def.grid, def.p, TILE_SCALE);
+    subCtx.restore();
+  });
+
+  addCanvasTexture(scene, 'tileset', c);
+
+  // Return tile index map
+  const map = {};
+  keys.forEach((k, i) => { map[k] = i; });
+  return map;
+}
+
+// ─── PLAYER SPRITE SHEET ──────────────────────────────────────────────────────
+// 4 directions × 3 frames each = 12 frames, 16×16 each → sheet 192×16
+
+const PLAYER_FRAMES = {
+  // down walk: frames 0,1,2
+  down: [
+    // frame 0 (stand)
+    [
+      '....SSSSSSSS....',
+      '...SSSSSSSSSS...',
+      '...SsSSSSSSsS...',
+      '...SSSSSSSSSS...',
+      '....HHHHHHHH....',
+      '...HhHHHHHhHH...',
+      '..HHHHHHHHHHHH..',
+      '..HHHHbbHHHHHH..',
+      '..HHHHHHHHHHHH..',
+      '..BBBBBBBBBBBB..',
+      '..BBBBBBBBBBB...',
+      '..BBB......BBB..',
+      '...LL......LL...',
+      '...LL......LL...',
+      '..llll....llll..',
+      '................',
+    ],
+    // frame 1 (walk L)
+    [
+      '....SSSSSSSS....',
+      '...SSSSSSSSSS...',
+      '...SsSSSSSSsS...',
+      '...SSSSSSSSSS...',
+      '....HHHHHHHH....',
+      '...HhHHHHHhHH...',
+      '..HHHHHHHHHHHH..',
+      '..HHHHbbHHHHHH..',
+      '..HHHHHHHHHHHH..',
+      '..BBBBBBBBBBBB..',
+      '..BBBBBBBBBBB...',
+      '..BBB......BBB..',
+      '..LLL......LL...',
+      '...LL......LLL..',
+      '..llll.....lll..',
+      '................',
+    ],
+    // frame 2 (walk R)
+    [
+      '....SSSSSSSS....',
+      '...SSSSSSSSSS...',
+      '...SsSSSSSSsS...',
+      '...SSSSSSSSSS...',
+      '....HHHHHHHH....',
+      '...HhHHHHHhHH...',
+      '..HHHHHHHHHHHH..',
+      '..HHHHbbHHHHHH..',
+      '..HHHHHHHHHHHH..',
+      '..BBBBBBBBBBBB..',
+      '..BBBBBBBBBBB...',
+      '..BBB......BBB..',
+      '...LL......LLL..',
+      '..LLL......LL...',
+      '..lll.....llll..',
+      '................',
+    ],
+  ],
+};
+
+const PLAYER_PALETTE = {
+  S: NES.skin,    s: NES.darkskin,
+  H: NES.lgreen,  h: NES.green,    // green tunic — easy to read as hero
+  b: NES.lyellow,                   // gold belt/buckle detail
+  B: NES.lblue,                     // blue pants
+  L: NES.lbrown,  l: NES.brown,    // brown boots
+  '.': null,
+};
+
+// Directions: down=0, left=1, right=2, up=3 (each 3 frames)
+function makePlayerFrame(frameIdx, dirOffset, palette) {
+  const frames = PLAYER_FRAMES.down; // reuse for all dirs
+  const src = frames[frameIdx % 3];
+  return { grid: src, p: palette };
+}
+
+export function generatePlayerSheet(scene) {
+  const FRAMES = 12; // 4 dirs × 3 frames
+  const FS = 16;
+  const SCALE = 2;
+  const W = FRAMES * FS * SCALE;
+  const H = FS * SCALE;
+
+  const c = createCanvas(W, H);
+  const ctx = c.getContext('2d');
+
+  // Dir-specific palette tints for left/right (slight flip simulation)
+  const palettes = [
+    PLAYER_PALETTE, // down
+    { ...PLAYER_PALETTE }, // left — same base
+    { ...PLAYER_PALETTE }, // right
+    { ...PLAYER_PALETTE, H: NES.lbrown }, // up (show back)
+  ];
+
+  for (let dir = 0; dir < 4; dir++) {
+    for (let f = 0; f < 3; f++) {
+      const frameIdx = dir * 3 + f;
+      const ox = frameIdx * FS * SCALE;
+      const src = PLAYER_FRAMES.down[f % 3];
+      ctx.save();
+      ctx.translate(ox, 0);
+      // Flip horizontally for left-facing
+      if (dir === 1) {
+        ctx.translate(FS * SCALE, 0);
+        ctx.scale(-1, 1);
+      }
+      drawGrid(ctx, src, palettes[dir], SCALE);
+      ctx.restore();
+    }
+  }
+
+  addCanvasSpriteSheet(scene, 'player', c, FS * SCALE, FS * SCALE);
+}
+
+// ─── ENEMY SPRITES ────────────────────────────────────────────────────────────
+
+const ENEMY_DEFS = {
+  dust_bunny: {
+    frames: [
+      [
+        '....WWWWWWWW....',
+        '..WWWWWWWWWWWW..',
+        '.WWWWWwWWWwWWWW.',
+        'WWWWWWWWWWWWWWwW',
+        'WWwWWWWWWWWWWWWW',
+        'WWWWWWbbWWbbWWWW',
+        'WWWWWWbbWWbbWWWW',
+        'WWWWWWWWRRWWWWWW',
+        'WWWWWWWWWWWWWWWW',
+        '.WWWWWWWWWWWWWW.',
+        '..WWWWWWWWWWWW..',
+        '...WWWWWWWWWW...',
+        '....EEEEEEEE....',
+        '.....EEEEEE.....',
+        '....EE....EE....',
+        '................',
+      ],
+      [
+        '....WWWWWWWW....',
+        '..WWWWWWWWWWWW..',
+        '.WWWwWWWWWWwWWW.',
+        'WwWWWWWWWWWWWWWW',
+        'WWWWWWWwWWWWWWWW',
+        'WWWWWWbbWWbbWWWW',
+        'WWWWWWbbWWbbWWWW',
+        'WWWWWWWWRRWWWWWW',
+        'WWWWWWWWWWWWWWWW',
+        '.WWWWWWWWWWWWWW.',
+        '..WWWWWWWWWWWW..',
+        '...WWWWWWWWWW...',
+        '....EEEEEEEE....',
+        '.....EEEEEE.....',
+        '....EE....EE....',
+        '................',
+      ],
+    ],
+    p: { W: NES.lgray, w: NES.white, b: NES.black, R: NES.lred, E: NES.lbrown, '.': null },
+  },
+  sock_goblin: {
+    frames: [
+      [
+        '......PPPP......',
+        '.....PPPPPP.....',
+        '....PPpPPpPP....',
+        '....PPPPPPPP....',
+        '....PPBBbbPP....',
+        '....PPBBbbPP....',
+        '....PPPPPPPP....',
+        '...PPPPPPPPPP...',
+        '..PPPPPPPPPPPP..',
+        '..PPSSSSSSSSPP..',
+        '..PPSSSSSSSSPP..',
+        '..PPPPPPPPPPPP..',
+        '....PP....PP....',
+        '....PP....PP....',
+        '...PPP....PPP...',
+        '................',
+      ],
+      [
+        '......PPPP......',
+        '.....PPPPPP.....',
+        '....PPpPPpPP....',
+        '....PPPPPPPP....',
+        '....PPBBbbPP....',
+        '....PPBBbbPP....',
+        '....PPPPPPPP....',
+        '..PPPPPPPPPPPP..',
+        '...PPPPPPPPPP...',
+        '..PPSSSSSSSSPP..',
+        '..PPSSSSSSSSPP..',
+        '..PPPPPPPPPPPP..',
+        '....PP....PP....',
+        '...PPP....PP....',
+        '....PP....PPP...',
+        '................',
+      ],
+    ],
+    p: { P: NES.lpurple, p: NES.purple, B: NES.black, b: NES.mgray, S: NES.lgray, '.': null },
+  },
+  crumb_slime: {
+    frames: [
+      [
+        '................',
+        '................',
+        '......BBBB......',
+        '....BBBBBBBB....',
+        '...BBBbbBBBBB...',
+        '..BBBBBBbbBBBB..',
+        '..BBBBbbBBBBBB..',
+        '..BBBBBBBBBBBB..',
+        '..BBwwBBBwwBBB..',
+        '..BBwwBBBwwBBB..',
+        '..BBBBBBBBBBBB..',
+        '...BBBBBBBBBB...',
+        '....BBBBBBBB....',
+        '......BBBB......',
+        '................',
+        '................',
+      ],
+      [
+        '................',
+        '......BBBB......',
+        '....BBBBBBBB....',
+        '...BBBbbBBBBB...',
+        '..BBBBBBbbBBBB..',
+        '..BBBBbbBBBBBB..',
+        '..BBBBBBBBBBBB..',
+        '..BBwwBBBwwBBB..',
+        '..BBwwBBBwwBBB..',
+        '..BBBBBBBBBBBB..',
+        '...BBBBBBBBBB...',
+        '....BBBBBBBB....',
+        '......BBBB......',
+        '................',
+        '................',
+        '................',
+      ],
+    ],
+    p: { B: NES.lbrown, b: NES.brown, w: NES.white, '.': null },
+  },
+};
+
+export function generateEnemySheets(scene) {
+  Object.entries(ENEMY_DEFS).forEach(([key, def]) => {
+    const FRAMES = def.frames.length;
+    const FS = 16;
+    const SCALE = 2;
+    const c = createCanvas(FRAMES * FS * SCALE, FS * SCALE);
+    const ctx = c.getContext('2d');
+    def.frames.forEach((grid, i) => {
+      ctx.save();
+      ctx.translate(i * FS * SCALE, 0);
+      drawGrid(ctx, grid, def.p, SCALE);
+      ctx.restore();
+    });
+    addCanvasSpriteSheet(scene, `enemy_${key}`, c, FS * SCALE, FS * SCALE);
+  });
+}
+
+// ─── BUILDING SPRITES (32×32) ─────────────────────────────────────────────────
+
+const BUILDING_DEFS = {
+  kitchen: {
+    grid: [
+      '................RRRRRRRRRRRRRRRR',
+      '...............RRRRRRRRRRRRRRRRRR',
+      '..............RRRRRRRRRRRRRRRRRRRR',
+      '.............RRRRRRRRRRRRRRRRRRRRRR',
+      '............RRRRRRrRRRRRRrRRRRRRRR',
+      '...........RRRRRRRrRRRRRRrRRRRRRRRR',
+      '...........RRRRRRRRRRRRRRRRRRRRRRRR.',
+      '...........WWWWWWWWWWWWWWWWWWWWWWW.',
+      '...........WbbWWWWWbbbbbbbWWWWbbW..',
+      '...........WbbWWWWWbbbbbbbWWWWbbW..',
+      '...........WbbWWWWWbbbbbbbWWWWbbW..',
+      '...........WWWWWWWWWWWWWWWWWWWWWW..',
+      '...........WWWWWWWWWWWWWWWWWWWWWW..',
+      '...........WWDDDWWWWWWWWWWWWWWWWW..',
+      '...........WWDDDWWWWWWWWWWWWWWWWW..',
+      '...........WWDDDWWWWWWWWWWWWWWWWW..',
+      '...........WWWWWWWWWWWWWWWWWWWWWW..',
+      '...........WWWWWWWWWWWWWWWWWWWWWW..',
+      '...........WWWWWWWWWWWWWWWWWWWWWW..',
+      '...........GGGGGGGGGGGGGGGGGGGGGG..',
+      '...........GGGGGGGGGGGGGGGGGGGGGG..',
+      '...........GGGGGGGGGGGGGGGGGGGGGG..',
+      '...........GGGGGGGGGGGGGGGGGGGGGG..',
+      '...........GGGGGGGGGGGGGGGGGGGGGG..',
+      '...........GGGGGGGGGGGGGGGGGGGGGG..',
+      '...........GGGGGGGGGGGGGGGGGGGGGG..',
+      '...........GGGGGGGGGGGGGGGGGGGGGG..',
+      '...........GGGGGGGGGGGGGGGGGGGGGG..',
+      '...........GGGGGGGGGGGGGGGGGGGGGG..',
+      '..........GGGGGGGGGGGGGGGGGGGGGGG..',
+      '..........GGGGGGGGGGGGGGGGGGGGGGG..',
+      '..........GGGGGGGGGGGGGGGGGGGGGGG..',
+    ],
+    p: {
+      R: NES.red, r: NES.lred,
+      W: NES.lgray, w: NES.white,
+      b: NES.sky, D: NES.brown,
+      G: NES.lgreen, '.': null,
+    },
+  },
+  laundry: {
+    grid: [
+      '................BBBBBBBBBBBBBBBB',
+      '...............BBBBBBBBBBBBBBBBBB',
+      '..............BBBBBBbBBBBBbBBBBBBB',
+      '.............BBBBBBBbBBBBBbBBBBBBBB',
+      '............BBBBBBBBbBBBBBbBBBBBBBBB',
+      '...........BBBBBBBBBBBBBBBBBBBBBBBBB.',
+      '...........WWWWWWWWWWWWWWWWWWWWWWWW.',
+      '...........WrrrrrrWWrrrrrrWWrrrrrrrW.',
+      '...........WrCCCCrWWrCCCCrWWrCCCCrW.',
+      '...........WrCCCCrWWrCCCCrWWrCCCCrW.',
+      '...........WrCCCCrWWrCCCCrWWrCCCCrW.',
+      '...........WrrrrrrWWrrrrrrWWrrrrrrrW.',
+      '...........WWWWWWWWWWWWWWWWWWWWWWWW.',
+      '...........WWDDDWWWWWWWWWWWWWWWWWWW.',
+      '...........WWDDDWWWWWWWWWWWWWWWWWWW.',
+      '...........WWDDDWWWWWWWWWWWWWWWWWWW.',
+      '...........WWWWWWWWWWWWWWWWWWWWWWWW.',
+      '...........GGGGGGGGGGGGGGGGGGGGGGGG.',
+      '...........GGGGGGGGGGGGGGGGGGGGGGGG.',
+      '...........GGGGGGGGGGGGGGGGGGGGGGGG.',
+      '...........GGGGGGGGGGGGGGGGGGGGGGGG.',
+      '...........GGGGGGGGGGGGGGGGGGGGGGGG.',
+      '...........GGGGGGGGGGGGGGGGGGGGGGGG.',
+      '...........GGGGGGGGGGGGGGGGGGGGGGGG.',
+      '...........GGGGGGGGGGGGGGGGGGGGGGGG.',
+      '...........GGGGGGGGGGGGGGGGGGGGGGGG.',
+      '...........GGGGGGGGGGGGGGGGGGGGGGGG.',
+      '..........GGGGGGGGGGGGGGGGGGGGGGGGG.',
+      '..........GGGGGGGGGGGGGGGGGGGGGGGGG.',
+      '..........GGGGGGGGGGGGGGGGGGGGGGGGG.',
+      '..........GGGGGGGGGGGGGGGGGGGGGGGGG.',
+      '..........GGGGGGGGGGGGGGGGGGGGGGGGG.',
+    ],
+    p: {
+      B: NES.lblue, b: NES.blue,
+      W: NES.lgray, r: NES.lred, C: NES.sky,
+      D: NES.brown, G: NES.lgreen, '.': null,
+    },
+  },
+  reward_castle: {
+    grid: [
+      'YYYY..YYYYYY..YYYY......YYYY..YYYYYY..YYYY',
+      'YYYY..YYYYYY..YYYY......YYYY..YYYYYY..YYYY',
+      'YYYYYYYYYYYYYYYYYY......YYYYYYYYYYYYYYYYYY',
+      'YYYYYYYYYYYYYYYYYY......YYYYYYYYYYYYYYYYYY',
+      'YYYYYYYYYYYYYYYYYYyyyyyYYYYYYYYYYYYYYYYYY',
+      'YYYYYYYYYYYYYYYYYYyyyyyYYYYYYYYYYYYYYYYYY',
+      'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY',
+      'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY',
+      'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW',
+      'WbbWWWWWWbbbbbbbbbbbbbbbbbbbbbWWWWWWWbbW',
+      'WbbWWWWWWbbbbbbbbbbbbbbbbbbbbbWWWWWWWbbW',
+      'WbbWWWWWWbbbbbbbbbbbbbbbbbbbbbWWWWWWWbbW',
+      'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW',
+      'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW',
+      'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW',
+      'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW',
+      'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW',
+      'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW',
+      'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW',
+      'WWWWWWWWWWWDDDDDDWWWWWWWDDDDDDWWWWWWWWWWWW',
+      'WWWWWWWWWWWDDDDDDWWWWWWWDDDDDDWWWWWWWWWWWW',
+      'WWWWWWWWWWWDDDDDDWWWWWWWDDDDDDWWWWWWWWWWWW',
+      'WWWWWWWWWWWDDDDDDWWWWWWWDDDDDDWWWWWWWWWWWW',
+      'WWWWWWWWWWWDDDDDDWWWWWWWDDDDDDWWWWWWWWWWWW',
+      'WWWWWWWWWWWDDDDDDWWWWWWWDDDDDDWWWWWWWWWWWW',
+      'WWWWWWWWWWWWWWWWWDDDDDDDWWWWWWWWWWWWWWWWWW',
+      'WWWWWWWWWWWWWWWWWDDDDDDDWWWWWWWWWWWWWWWWWW',
+      'WWWWWWWWWWWWWWWWWDDDDDDDWWWWWWWWWWWWWWWWWW',
+      'WWWWWWWWWWWWWWWWWDDDDDDDWWWWWWWWWWWWWWWWWW',
+      'GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG',
+      'GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG',
+      'GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG',
+    ],
+    p: {
+      Y: NES.yellow, y: NES.lyellow,
+      W: NES.lgray, b: NES.sky,
+      D: NES.brown, G: NES.lgreen, '.': null,
+    },
+  },
+};
+
+export function generateBuildingSprites(scene) {
+  Object.entries(BUILDING_DEFS).forEach(([key, def]) => {
+    const rows = def.grid.length;
+    const cols = def.grid[0].length;
+    const SCALE = 1;
+    const c = createCanvas(cols * SCALE, rows * SCALE);
+    const ctx = c.getContext('2d');
+    drawGrid(ctx, def.grid, def.p, SCALE);
+    addCanvasTexture(scene, `building_${key}`, c);
+  });
+}
+
+// ─── UI SPRITES ───────────────────────────────────────────────────────────────
+
+export function generateUISprites(scene) {
+  // Portal / quest marker — animated 16×16
+  const PORTAL_FRAMES = 4;
+  const FS = 16;
+  const SCALE = 2;
+  const pc = createCanvas(PORTAL_FRAMES * FS * SCALE, FS * SCALE);
+  const pctx = pc.getContext('2d');
+  const portalColors = [NES.lyellow, NES.yellow, NES.lorange, NES.yellow];
+  const portalRings  = [NES.lgreen,  NES.green,  NES.lteal,   NES.teal];
+
+  for (let f = 0; f < PORTAL_FRAMES; f++) {
+    pctx.save();
+    pctx.translate(f * FS * SCALE, 0);
+    // Outer ring
+    pctx.fillStyle = portalRings[f];
+    pctx.fillRect(4 * SCALE, 2 * SCALE, 8 * SCALE, 12 * SCALE);
+    pctx.fillRect(2 * SCALE, 4 * SCALE, 12 * SCALE, 8 * SCALE);
+    // Inner glow
+    pctx.fillStyle = portalColors[f];
+    pctx.fillRect(5 * SCALE, 3 * SCALE, 6 * SCALE, 10 * SCALE);
+    pctx.fillRect(3 * SCALE, 5 * SCALE, 10 * SCALE, 6 * SCALE);
+    // Center
+    pctx.fillStyle = NES.white;
+    pctx.fillRect(6 * SCALE, 6 * SCALE, 4 * SCALE, 4 * SCALE);
+    pctx.restore();
+  }
+  addCanvasSpriteSheet(scene, 'portal', pc, FS * SCALE, FS * SCALE);
+
+  // Coin sprite (8×8, 2 frames)
+  const cc = createCanvas(4 * 8 * SCALE, 8 * SCALE);
+  const cctx = cc.getContext('2d');
+  [[NES.yellow, NES.lyellow], [NES.lyellow, NES.white], [NES.yellow, NES.lyellow], [NES.lorange, NES.yellow]].forEach(([bg, hi], f) => {
+    cctx.save();
+    cctx.translate(f * 8 * SCALE, 0);
+    cctx.fillStyle = bg;
+    cctx.fillRect(2 * SCALE, 0, 4 * SCALE, 8 * SCALE);
+    cctx.fillRect(1 * SCALE, 1 * SCALE, 6 * SCALE, 6 * SCALE);
+    cctx.fillStyle = hi;
+    cctx.fillRect(2 * SCALE, 1 * SCALE, 2 * SCALE, 3 * SCALE);
+    cctx.restore();
+  });
+  addCanvasSpriteSheet(scene, 'coin', cc, 8 * SCALE, 8 * SCALE);
+
+  // Heart sprite (8×8, 2 states: full/empty)
+  const hc = createCanvas(2 * 8 * SCALE, 8 * SCALE);
+  const hctx = hc.getContext('2d');
+  [[NES.red, NES.lred], [NES.dgray, NES.mgray]].forEach(([fg, hi], f) => {
+    hctx.save();
+    hctx.translate(f * 8 * SCALE, 0);
+    hctx.fillStyle = fg;
+    hctx.fillRect(1 * SCALE, 2 * SCALE, 2 * SCALE, 2 * SCALE);
+    hctx.fillRect(5 * SCALE, 2 * SCALE, 2 * SCALE, 2 * SCALE);
+    hctx.fillRect(0 * SCALE, 3 * SCALE, 8 * SCALE, 3 * SCALE);
+    hctx.fillRect(1 * SCALE, 6 * SCALE, 6 * SCALE, 1 * SCALE);
+    hctx.fillRect(2 * SCALE, 7 * SCALE, 4 * SCALE, 1 * SCALE);
+    hctx.fillStyle = hi;
+    hctx.fillRect(1 * SCALE, 2 * SCALE, 1 * SCALE, 1 * SCALE);
+    hctx.fillRect(5 * SCALE, 2 * SCALE, 1 * SCALE, 1 * SCALE);
+    hctx.restore();
+  });
+  addCanvasSpriteSheet(scene, 'heart', hc, 8 * SCALE, 8 * SCALE);
+
+  // XP bar background (128×8)
+  const xpW = 128, xpH = 8;
+  const xpc = createCanvas(xpW, xpH);
+  const xpctx = xpc.getContext('2d');
+  xpctx.fillStyle = NES.black;
+  xpctx.fillRect(0, 0, xpW, xpH);
+  xpctx.fillStyle = NES.dgray;
+  xpctx.fillRect(1, 1, xpW - 2, xpH - 2);
+  addCanvasTexture(scene, 'xpbar_bg', xpc);
+
+  const xpfc = createCanvas(xpW, xpH);
+  const xpfctx = xpfc.getContext('2d');
+  xpfctx.fillStyle = NES.lgreen;
+  xpfctx.fillRect(0, 0, xpW, xpH);
+  xpfctx.fillStyle = NES.green;
+  xpfctx.fillRect(0, xpH - 2, xpW, 2);
+  addCanvasTexture(scene, 'xpbar_fill', xpfc);
+}
+
+export function generateAllSprites(scene) {
+  generatePlayerSheet(scene);
+  generateEnemySheets(scene);
+  generateBuildingSprites(scene);
+  generateUISprites(scene);
+  return generateTileset(scene);
+}

--- a/frontend/src/game/systems/BattleSystem.js
+++ b/frontend/src/game/systems/BattleSystem.js
@@ -61,8 +61,13 @@ export class BattleSystem {
   }
 
   defeatEnemy(enemy) {
-    const xpDrop    = enemy.xpDrop    ?? 2;
-    const coinDrop  = enemy.coinDrop  ?? 1;
+    // Mark inactive immediately so hurtEnemy's `if (!enemy.active) return` guard
+    // blocks any second hit during the 300 ms death tween, preventing double XP/coins.
+    enemy.setActive(false);
+    enemy.body?.setEnable(false); // also disable physics body so overlaps stop firing
+
+    const xpDrop   = enemy.xpDrop   ?? 2;
+    const coinDrop = enemy.coinDrop ?? 1;
     this.scene.events.emit('enemyDefeated', { enemy, xpDrop, coinDrop });
 
     this.scene.tweens.add({

--- a/frontend/src/game/systems/BattleSystem.js
+++ b/frontend/src/game/systems/BattleSystem.js
@@ -1,0 +1,98 @@
+// Lightweight battle resolution — no turn-based menu, just collision-driven.
+// Player swings weapon -> emits 'playerAttack' event.
+// Enemy touches player -> triggers damage.
+
+import { WEAPON_STATS } from '../data/WorldData.js';
+
+export class BattleSystem {
+  constructor(scene) {
+    this.scene   = scene;
+    this.cooldowns = {};
+  }
+
+  canAttack(weapon) {
+    const now  = Date.now();
+    const last = this.cooldowns[weapon] || 0;
+    return now - last >= (WEAPON_STATS[weapon]?.cooldown ?? 500);
+  }
+
+  // Returns damage dealt (or 0 if on cooldown)
+  playerAttack(weapon, enemies, playerSprite) {
+    if (!this.canAttack(weapon)) return 0;
+    this.cooldowns[weapon] = Date.now();
+
+    const stats  = WEAPON_STATS[weapon] ?? WEAPON_STATS.broom;
+    const range  = stats.range;
+    const damage = stats.damage;
+    let   hit    = 0;
+
+    enemies.getChildren().forEach((enemy) => {
+      if (!enemy.active) return;
+      const dx = enemy.x - playerSprite.x;
+      const dy = enemy.y - playerSprite.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist <= range) {
+        this.hurtEnemy(enemy, damage);
+        hit++;
+      }
+    });
+    return hit;
+  }
+
+  hurtEnemy(enemy, damage) {
+    if (!enemy.active) return;
+    enemy.hp = (enemy.hp ?? enemy.maxHp) - damage;
+    this.scene.events.emit('enemyHurt', { enemy, damage });
+
+    // Bright red tint flash — much more readable than an alpha dip
+    enemy.setTint(0xff2222);
+    this.scene.tweens.add({
+      targets: enemy,
+      alpha: 0.5,
+      duration: 60,
+      yoyo: true,
+      repeat: 1,
+      onComplete: () => { enemy.clearTint(); enemy.setAlpha(1); },
+    });
+
+    if (enemy.hp <= 0) {
+      this.defeatEnemy(enemy);
+    }
+  }
+
+  defeatEnemy(enemy) {
+    const xpDrop    = enemy.xpDrop    ?? 2;
+    const coinDrop  = enemy.coinDrop  ?? 1;
+    this.scene.events.emit('enemyDefeated', { enemy, xpDrop, coinDrop });
+
+    this.scene.tweens.add({
+      targets: enemy,
+      alpha: 0,
+      scaleX: 2,
+      scaleY: 2,
+      duration: 300,
+      onComplete: () => enemy.destroy(),
+    });
+  }
+
+  // Called when an enemy overlaps the player
+  enemyContactDamage(player, enemy) {
+    const now  = Date.now();
+    const key  = `player_iframes`;
+    const last = this.cooldowns[key] || 0;
+    if (now - last < 1000) return; // 1 s invincibility
+    this.cooldowns[key] = now;
+
+    this.scene.events.emit('playerHurt', { damage: 1 });
+
+    // Red flash on player
+    this.scene.tweens.add({
+      targets: player,
+      tint: 0xff0000,
+      duration: 100,
+      yoyo: true,
+      repeat: 3,
+      onComplete: () => player.clearTint(),
+    });
+  }
+}

--- a/frontend/src/game/systems/SaveSystem.js
+++ b/frontend/src/game/systems/SaveSystem.js
@@ -1,0 +1,84 @@
+// IndexedDB-backed save system for Adventure Mode.
+// Saves are keyed by userId so each family member has a separate slot.
+
+const DB_NAME    = 'chorequest_adventure';
+const DB_VERSION = 1;
+const STORE      = 'saves';
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = (e) => {
+      const db = e.target.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE, { keyPath: 'userId' });
+      }
+    };
+    req.onsuccess = (e) => resolve(e.target.result);
+    req.onerror   = (e) => reject(e.target.error);
+  });
+}
+
+export const defaultSave = (userId) => ({
+  userId,
+  level: 1,
+  xp: 0,
+  coins: 0,
+  hp: 10,
+  maxHp: 10,
+  weapon: 'broom',
+  unlockedWeapons: ['broom'],
+  playerX: 640,
+  playerY: 640,
+  completedChoreIds: [],
+  portalRestoreLevels: {},
+  equippedHat: null,
+  tutorialSeen: false,
+  savedAt: Date.now(),
+});
+
+export async function loadSave(userId) {
+  try {
+    const db    = await openDB();
+    const tx    = db.transaction(STORE, 'readonly');
+    const store = tx.objectStore(STORE);
+    return await new Promise((resolve, reject) => {
+      const req = store.get(userId);
+      req.onsuccess = (e) => resolve(e.target.result || null);
+      req.onerror   = (e) => reject(e.target.error);
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function writeSave(data) {
+  try {
+    const db    = await openDB();
+    const tx    = db.transaction(STORE, 'readwrite');
+    const store = tx.objectStore(STORE);
+    data.savedAt = Date.now();
+    await new Promise((resolve, reject) => {
+      const req = store.put(data);
+      req.onsuccess = resolve;
+      req.onerror   = (e) => reject(e.target.error);
+    });
+  } catch (err) {
+    console.warn('[SaveSystem] write failed', err);
+  }
+}
+
+export async function deleteSave(userId) {
+  try {
+    const db    = await openDB();
+    const tx    = db.transaction(STORE, 'readwrite');
+    const store = tx.objectStore(STORE);
+    await new Promise((resolve, reject) => {
+      const req = store.delete(userId);
+      req.onsuccess = resolve;
+      req.onerror   = (e) => reject(e.target.error);
+    });
+  } catch (err) {
+    console.warn('[SaveSystem] delete failed', err);
+  }
+}

--- a/frontend/src/game/systems/SaveSystem.js
+++ b/frontend/src/game/systems/SaveSystem.js
@@ -24,8 +24,8 @@ export const defaultSave = (userId) => ({
   level: 1,
   xp: 0,
   coins: 0,
-  hp: 10,
-  maxHp: 10,
+  hp: 5,
+  maxHp: 5,   // matches MAX_HEARTS (5) in HUD.js — each heart = 1 HP
   weapon: 'broom',
   unlockedWeapons: ['broom'],
   playerX: 640,

--- a/frontend/src/game/systems/SoundSystem.js
+++ b/frontend/src/game/systems/SoundSystem.js
@@ -1,0 +1,359 @@
+// SoundSystem.js — Procedural 8-bit audio for Adventure Mode.
+// All sounds synthesized at runtime via Web Audio API. No external files.
+//
+// Timbres mirror the NES sound chip (2A03):
+//   Pulse 1 (melody)  — 25% duty square wave
+//   Pulse 2 (harmony) — 50% duty square wave
+//   Triangle (bass)   — triangle wave
+//   Noise (drums/sfx) — white noise + filters
+
+// ── Note table (Hz) ──────────────────────────────────────────────────────────
+const HZ = {
+  A2:110.00, B2:123.47,
+  C3:130.81, D3:146.83, E3:164.81, F3:174.61, G3:196.00,
+  A3:220.00, B3:246.94,
+  C4:261.63, D4:293.66, E4:329.63, F4:349.23, G4:392.00,
+  A4:440.00, B4:493.88,
+  C5:523.25, D5:587.33, E5:659.25, F5:698.46, G5:783.99,
+  A5:880.00, B5:987.77,
+  C6:1046.50, D6:1174.66, E6:1318.51,
+};
+const _ = null; // rest
+
+// ── Timing (120 BPM) ─────────────────────────────────────────────────────────
+const Q = 0.50; // quarter note
+const E = 0.25; // 8th note
+const H = 1.00; // half note
+
+// ── "Broken Village" BGM — A natural minor, 8-bar loop (16 s) ───────────────
+// Pulse 1: melody (25% duty square)
+const MELODY = [
+  // ── A section (bars 1–4) ──────────────────────────────────────────────────
+  [HZ.A5,E],[HZ.G5,E],[HZ.E5,E],[_,E],[HZ.G5,E],[HZ.E5,E],[HZ.D5,E],[_,E],
+  [HZ.E5,E],[HZ.D5,E],[HZ.C5,E],[HZ.A4,E],[_,H],
+  [HZ.G5,E],[HZ.A5,E],[HZ.G5,E],[HZ.E5,E],[HZ.G5,E],[HZ.E5,E],[HZ.D5,E],[HZ.C5,E],
+  [HZ.D5,E],[_,E],[HZ.E5,E],[_,E],[HZ.A4,Q],[_,Q],
+  // ── B section (bars 5–8) ──────────────────────────────────────────────────
+  [HZ.C5,E],[HZ.D5,E],[HZ.E5,E],[HZ.G5,E],[HZ.A5,E],[_,E],[HZ.G5,E],[_,E],
+  [HZ.G5,E],[HZ.E5,E],[HZ.D5,E],[HZ.C5,E],[HZ.B4,E],[_,E],[HZ.A4,E],[_,E],
+  [HZ.C5,E],[HZ.B4,E],[HZ.A4,E],[HZ.G4,E],[HZ.A4,Q],[_,Q],
+  [HZ.A4,Q],[_,Q],[_,H],
+];
+
+// Triangle: bass line
+const BASS = [
+  [HZ.A3,Q],[_,Q],[HZ.E3,Q],[_,Q],
+  [HZ.A3,Q],[_,Q],[HZ.A3,Q],[_,Q],
+  [HZ.C4,Q],[_,Q],[HZ.G3,Q],[_,Q],
+  [HZ.A3,Q],[_,Q],[HZ.E3,Q],[_,Q],
+  [HZ.C4,Q],[_,Q],[HZ.G3,Q],[_,Q],
+  [HZ.G3,Q],[_,Q],[HZ.G3,Q],[_,Q],
+  [HZ.A2,Q],[_,Q],[HZ.E3,Q],[_,Q],
+  [HZ.A2,H],[_,H],
+];
+
+// Pulse 2: harmony (50% duty square, lower volume)
+const HARMONY = [
+  [HZ.C5,H],[HZ.E4,H],
+  [HZ.A4,H],[_,H],
+  [HZ.C5,H],[HZ.G4,H],
+  [HZ.A4,H],[_,H],
+  [HZ.C5,H],[HZ.E5,H],
+  [HZ.G4,H],[HZ.B4,H],
+  [HZ.C5,H],[HZ.A4,H],
+  [HZ.A4,H],[_,H],
+];
+
+const LOOP_DUR = MELODY.reduce((s, [, d]) => s + d, 0); // 16.0 s
+
+// ── SoundSystem ──────────────────────────────────────────────────────────────
+export class SoundSystem {
+  constructor(scene) {
+    this._ctx  = scene.sound.context;
+    this._dead = false;
+
+    // Master gain → destination
+    this._master = this._ctx.createGain();
+    this._master.gain.value = 0.28;
+    this._master.connect(this._ctx.destination);
+
+    // Pre-baked NES pulse duty-cycle waves
+    this._w25 = this._makeWave(0.25);  // NES pulse-channel "thin" sound
+    this._w12 = this._makeWave(0.125); // even thinner, for portal chimes
+
+    // Pre-cached noise buffers (reused for every drum hit)
+    this._noiseBufs = {
+      kick:  this._makeNoiseBuf(0.14),
+      snare: this._makeNoiseBuf(0.09),
+      hat:   this._makeNoiseBuf(0.035),
+      sfx:   this._makeNoiseBuf(0.35),
+    };
+
+    this._nextLoop  = null;
+    this._loopTimer = null;
+  }
+
+  // ── Utility builders ────────────────────────────────────────────────────────
+
+  // Fourier-series PeriodicWave for a pulse wave with given duty cycle.
+  _makeWave(duty) {
+    const N = 64;
+    const real = new Float32Array(N);
+    const imag = new Float32Array(N);
+    for (let k = 1; k < N; k++) {
+      imag[k] = (2 / (k * Math.PI)) * Math.sin(k * Math.PI * duty);
+    }
+    return this._ctx.createPeriodicWave(real, imag);
+  }
+
+  // Pre-fill a noise buffer (shared across all playback nodes for that sound).
+  _makeNoiseBuf(dur) {
+    const sr  = this._ctx.sampleRate;
+    const len = Math.ceil(sr * dur);
+    const buf = this._ctx.createBuffer(1, len, sr);
+    const d   = buf.getChannelData(0);
+    for (let i = 0; i < len; i++) d[i] = Math.random() * 2 - 1;
+    return buf;
+  }
+
+  // Schedule a single oscillator tone with attack+release to avoid clicks.
+  _tone(hz, t, dur, vol = 0.25, type = 'square', wave = null) {
+    if (!hz || dur <= 0) return;
+    const ctx = this._ctx;
+    const osc = ctx.createOscillator();
+    const g   = ctx.createGain();
+
+    if (wave) osc.setPeriodicWave(wave);
+    else      osc.type = type;
+    osc.frequency.value = hz;
+
+    const attack  = Math.min(0.005, dur * 0.05);
+    const release = Math.min(0.015, dur * 0.1);
+    g.gain.setValueAtTime(0, t);
+    g.gain.linearRampToValueAtTime(vol, t + attack);
+    g.gain.setValueAtTime(vol, t + dur - release);
+    g.gain.linearRampToValueAtTime(0, t + dur);
+
+    osc.connect(g);
+    g.connect(this._master);
+    osc.start(t);
+    osc.stop(t + dur + 0.01);
+  }
+
+  // Play a noise buffer with optional hi-pass / lo-pass filter.
+  _noise(buf, t, vol, locut = 0, hicut = 0) {
+    const ctx = this._ctx;
+    const src = ctx.createBufferSource();
+    src.buffer = buf;
+
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(vol, t);
+    g.gain.exponentialRampToValueAtTime(0.0001, t + buf.duration);
+
+    let chain = src;
+    if (locut > 0) {
+      const hp = ctx.createBiquadFilter();
+      hp.type = 'highpass'; hp.frequency.value = locut;
+      chain.connect(hp); chain = hp;
+    }
+    if (hicut > 0) {
+      const lp = ctx.createBiquadFilter();
+      lp.type = 'lowpass'; lp.frequency.value = hicut;
+      chain.connect(lp); chain = lp;
+    }
+    chain.connect(g);
+    g.connect(this._master);
+    src.start(t);
+    // BufferSource stops automatically at end of buffer
+  }
+
+  // ── Sound effects ────────────────────────────────────────────────────────────
+
+  playAttack() {
+    const t = this._ctx.currentTime;
+    // Broom whoosh: square sweep down + hi-freq noise burst
+    const osc = this._ctx.createOscillator();
+    const g   = this._ctx.createGain();
+    osc.type = 'square';
+    osc.frequency.setValueAtTime(520, t);
+    osc.frequency.exponentialRampToValueAtTime(130, t + 0.09);
+    g.gain.setValueAtTime(0.22, t);
+    g.gain.linearRampToValueAtTime(0, t + 0.10);
+    osc.connect(g); g.connect(this._master);
+    osc.start(t); osc.stop(t + 0.11);
+    this._noise(this._noiseBufs.sfx, t, 0.07, 2000);
+  }
+
+  playHit() {
+    const t = this._ctx.currentTime;
+    // Punchy smack: band-passed noise + low thud
+    this._noise(this._noiseBufs.sfx, t, 0.22, 300, 5000);
+    this._tone(160, t, 0.06, 0.16, 'square');
+  }
+
+  playEnemyDefeat() {
+    const t = this._ctx.currentTime;
+    // Descending arpeggio — classic NES enemy-defeated sound
+    [[659, 0.00], [523, 0.07], [392, 0.14], [261, 0.21]].forEach(([f, dt]) => {
+      this._tone(f, t + dt, 0.11, 0.22, 'square', this._w25);
+    });
+    this._noise(this._noiseBufs.sfx, t, 0.10, 100, 4000);
+  }
+
+  playPortalEnter() {
+    const t = this._ctx.currentTime;
+    // Rising harp arpeggio — magical portal chime (very thin duty cycle)
+    [[440,0.00],[523,0.07],[659,0.14],[784,0.21],[1047,0.28],[1319,0.35]].forEach(([f, dt]) => {
+      this._tone(f, t + dt, 0.22, 0.14, 'square', this._w12);
+    });
+  }
+
+  playPlayerHurt() {
+    const t = this._ctx.currentTime;
+    // Descending sawtooth buzz — jarring hurt cue
+    const osc = this._ctx.createOscillator();
+    const g   = this._ctx.createGain();
+    osc.type = 'sawtooth';
+    osc.frequency.setValueAtTime(880, t);
+    osc.frequency.exponentialRampToValueAtTime(110, t + 0.28);
+    g.gain.setValueAtTime(0.28, t);
+    g.gain.linearRampToValueAtTime(0, t + 0.30);
+    osc.connect(g); g.connect(this._master);
+    osc.start(t); osc.stop(t + 0.31);
+    this._noise(this._noiseBufs.sfx, t, 0.15, 80, 3000);
+  }
+
+  playCoinPickup() {
+    const t = this._ctx.currentTime;
+    // Classic two-note bling (Mario-coin style)
+    this._tone(1046, t,        0.07, 0.20, 'square', this._w25);
+    this._tone(1319, t + 0.07, 0.12, 0.20, 'square', this._w25);
+  }
+
+  playLevelUp() {
+    const t = this._ctx.currentTime;
+    // 5-note ascending fanfare with triangle harmonics underneath
+    [[523,0.0],[659,0.1],[784,0.2],[1047,0.3],[1319,0.4]].forEach(([f, dt]) => {
+      this._tone(f,       t + dt,        0.18, 0.22, 'square',   this._w25);
+      this._tone(f * 1.5, t + dt + 0.01, 0.16, 0.08, 'triangle');
+    });
+  }
+
+  playChoreComplete() {
+    const t = this._ctx.currentTime;
+    // NES "got item" fanfare
+    const seq = [
+      [HZ.G5, E * 0.9], [HZ.A5, E * 0.9], [HZ.B5, E * 0.9],
+      [HZ.C6, E * 0.9], [HZ.D6, Q * 0.9],
+    ];
+    let off = 0;
+    seq.forEach(([f, d]) => {
+      this._tone(f, t + off, d, 0.22, 'square', this._w25);
+      off += d + 0.01;
+    });
+  }
+
+  // ── BGM sequencer ─────────────────────────────────────────────────────────────
+  // Uses the Web Audio clock for drift-free scheduling.
+  // Schedules one full 16 s loop, then re-schedules 500 ms before it ends.
+
+  startBGM() {
+    if (this._dead || this._loopTimer !== null) return;
+    this._nextLoop = this._ctx.currentTime + 0.05;
+    this._tick();
+  }
+
+  stopBGM() {
+    if (this._loopTimer !== null) {
+      clearTimeout(this._loopTimer);
+      this._loopTimer = null;
+    }
+  }
+
+  _tick() {
+    if (this._dead) return;
+    const loopStart = this._nextLoop;
+    this._nextLoop += LOOP_DUR;
+
+    // ── Schedule note patterns ──
+    this._playPattern(MELODY,   loopStart, 0.17, 'square',   this._w25, 0.88);
+    this._playPattern(BASS,     loopStart, 0.10, 'triangle', null,       0.92);
+    this._playPattern(HARMONY,  loopStart, 0.07, 'square',   null,       0.82);
+
+    // ── Schedule drum track ──
+    this._playDrums(loopStart);
+
+    // Re-schedule 500 ms before this loop ends so the next loop queues seamlessly
+    const msUntilNext = (this._nextLoop - this._ctx.currentTime - 0.5) * 1000;
+    this._loopTimer = setTimeout(() => {
+      this._loopTimer = null;
+      this._tick();
+    }, Math.max(50, msUntilNext));
+  }
+
+  _playPattern(pattern, loopStart, vol, type, wave, gate = 0.88) {
+    let t = loopStart;
+    pattern.forEach(([hz, dur]) => {
+      if (hz) this._tone(hz, t, dur * gate, vol, type, wave);
+      t += dur;
+    });
+  }
+
+  _playDrums(loopStart) {
+    const BAR = Q * 4; // 2.0 s per 4/4 bar at 120 BPM
+    for (let b = 0; b < 8; b++) {
+      const bs = loopStart + b * BAR;
+
+      // Beat 1 — kick
+      this._kick(bs);
+
+      // Beat 3 — snare (with slight 8th-note variation on bars 4 & 8)
+      const snareOffset = (b === 3 || b === 7) ? Q * 2 + E : Q * 2;
+      this._snare(bs + snareOffset);
+
+      // Every 8th note — hi-hat (quieter on off-beats)
+      for (let h = 0; h < 8; h++) {
+        const hatVol = (h % 2 === 0) ? 0.055 : 0.030; // on-beat louder
+        this._hat(bs + h * E, hatVol);
+      }
+    }
+  }
+
+  // NES-style kick: sine pitch-drop 120→40 Hz + low noise thud
+  _kick(t) {
+    const ctx = this._ctx;
+    const osc = ctx.createOscillator();
+    const g   = ctx.createGain();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(120, t);
+    osc.frequency.exponentialRampToValueAtTime(40, t + 0.10);
+    g.gain.setValueAtTime(0.30, t);
+    g.gain.exponentialRampToValueAtTime(0.001, t + 0.13);
+    osc.connect(g); g.connect(this._master);
+    osc.start(t); osc.stop(t + 0.14);
+    this._noise(this._noiseBufs.kick, t, 0.06, 0, 180); // body rumble
+  }
+
+  // NES-style snare: band-passed noise burst + pitch-popped square
+  _snare(t) {
+    this._noise(this._noiseBufs.snare, t, 0.18, 700, 9000);
+    this._tone(220, t, 0.04, 0.07, 'square');
+  }
+
+  // NES hi-hat: very short high-freq noise tick
+  _hat(t, vol = 0.045) {
+    this._noise(this._noiseBufs.hat, t, vol, 7000);
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────────
+
+  setVolume(v) {
+    this._master.gain.value = Math.max(0, Math.min(1, v));
+  }
+
+  destroy() {
+    this._dead = true;
+    this.stopBGM();
+    try { this._master.disconnect(); } catch (_) { /* already disconnected */ }
+  }
+}

--- a/frontend/src/game/ui/HUD.js
+++ b/frontend/src/game/ui/HUD.js
@@ -1,0 +1,211 @@
+// In-game HUD: hearts, XP bar, level, coin count, minimap indicator.
+// All elements are fixed to the camera (setScrollFactor(0)).
+
+import Phaser from 'phaser';
+import { xpForLevel, levelFromXp } from '../data/WorldData.js';
+
+const MAX_HEARTS   = 5;
+const HUD_DEPTH    = 100;
+const PADDING      = 8;
+const HEART_SCALE  = 3;            // 8px source × 3 = 24px display
+const HEART_SIZE   = 8 * HEART_SCALE;
+const HEART_GAP    = 3;
+
+export class HUD {
+  constructor(scene) {
+    this.scene   = scene;
+    this.hearts  = [];
+    this.xpMask  = null;
+    this._buildHUD();
+  }
+
+  _buildHUD() {
+    const scene = this.scene;
+    const cam   = scene.cameras.main;
+    const W     = cam.width;
+
+    const xpY  = PADDING + HEART_SIZE + 6;
+    const BAR_W = 128;
+    const HUD_BG_W = PADDING + MAX_HEARTS * (HEART_SIZE + HEART_GAP) + 4;
+    const HUD_BG_H = xpY + 12 + 6;
+
+    // ── Dark background strip for top-left HUD ───────────────────────
+    const bgLeft = scene.add.graphics();
+    bgLeft.fillStyle(0x000000, 0.55);
+    bgLeft.fillRoundedRect(2, 2, HUD_BG_W + 52, HUD_BG_H, 5);
+    bgLeft.setScrollFactor(0).setDepth(HUD_DEPTH - 1);
+
+    // ── Hearts (top-left) ────────────────────────────────────────────
+    for (let i = 0; i < MAX_HEARTS; i++) {
+      const hx = PADDING + i * (HEART_SIZE + HEART_GAP);
+      const hy = PADDING;
+      const empty = scene.add.image(hx, hy, 'heart', 1)
+        .setScrollFactor(0).setDepth(HUD_DEPTH).setOrigin(0).setScale(HEART_SCALE);
+      const full  = scene.add.image(hx, hy, 'heart', 0)
+        .setScrollFactor(0).setDepth(HUD_DEPTH + 1).setOrigin(0).setScale(HEART_SCALE);
+      this.hearts.push({ empty, full });
+    }
+
+    // ── XP bar (below hearts) ────────────────────────────────────────
+    scene.add.image(PADDING, xpY, 'xpbar_bg')
+      .setScrollFactor(0).setDepth(HUD_DEPTH).setOrigin(0).setScale(1.25, 1.5);
+
+    this.xpFill = scene.add.image(PADDING, xpY, 'xpbar_fill')
+      .setScrollFactor(0).setDepth(HUD_DEPTH + 1).setOrigin(0).setScale(1.25, 1.5);
+
+    this.xpFill.setCrop(0, 0, 0, 8);
+
+    // XP label (centered on bar)
+    this.xpLabel = scene.add.text(PADDING + BAR_W * 1.25 / 2, xpY + 6, 'XP 0', {
+      fontSize: '9px',
+      fontFamily: 'monospace',
+      color: '#ffffff',
+      stroke: '#000000',
+      strokeThickness: 3,
+      resolution: 2,
+    }).setScrollFactor(0).setDepth(HUD_DEPTH + 2).setOrigin(0.5);
+
+    // ── Level badge (right of XP bar) ────────────────────────────────
+    this.levelLabel = scene.add.text(PADDING + BAR_W * 1.25 + 6, xpY + 1, 'LV 1', {
+      fontSize: '10px',
+      fontFamily: 'monospace',
+      color: '#fcd860',
+      stroke: '#000000',
+      strokeThickness: 4,
+      resolution: 2,
+    }).setScrollFactor(0).setDepth(HUD_DEPTH);
+
+    // ── Coin counter (top-right) ──────────────────────────────────────
+    const coinX = W - PADDING - 48;
+    const bgRight = scene.add.graphics();
+    bgRight.fillStyle(0x000000, 0.55);
+    bgRight.fillRoundedRect(coinX - 4, 2, 60, 28, 5);
+    bgRight.setScrollFactor(0).setDepth(HUD_DEPTH - 1);
+
+    // Coin animation
+    if (!scene.anims.exists('coin_spin')) {
+      scene.anims.create({
+        key: 'coin_spin',
+        frames: scene.anims.generateFrameNumbers('coin', { start: 0, end: 3 }),
+        frameRate: 6,
+        repeat: -1,
+      });
+    }
+    const coinAnim = scene.add.sprite(coinX, PADDING + 2, 'coin')
+      .setScrollFactor(0).setDepth(HUD_DEPTH).setOrigin(0).setScale(2.5);
+    coinAnim.play('coin_spin');
+
+    this.coinLabel = scene.add.text(coinX + 24, PADDING + 8, '0', {
+      fontSize: '12px',
+      fontFamily: 'monospace',
+      color: '#fcd860',
+      stroke: '#000000',
+      strokeThickness: 4,
+      resolution: 2,
+    }).setScrollFactor(0).setDepth(HUD_DEPTH).setOrigin(0, 0.5);
+
+    // ── Touch action buttons (bottom) ────────────────────────────────
+    if (scene.sys.game.device.input.touch) {
+      this._buildTouchControls();
+    }
+  }
+
+  _buildTouchControls() {
+    const scene = this.scene;
+    const cam   = scene.cameras.main;
+    const W     = cam.width;
+    const H     = cam.height;
+    const BTN   = 40;
+    const GAP   = 6;
+
+    // D-pad cluster (bottom-left)
+    const padX = BTN + GAP;
+    const padY = H - BTN - GAP;
+
+    const dpadDefs = [
+      { label: '←', dx: -(BTN + GAP), dy: 0,          dir: 'left' },
+      { label: '→', dx:  (BTN + GAP), dy: 0,           dir: 'right' },
+      { label: '↑', dx: 0,            dy: -(BTN + GAP), dir: 'up' },
+      { label: '↓', dx: 0,            dy:  (BTN + GAP), dir: 'down' },
+    ];
+
+    this.touchKeys = {};
+
+    dpadDefs.forEach(({ label, dx, dy, dir }) => {
+      const btn = scene.add.rectangle(padX + dx, padY + dy, BTN, BTN, 0xffffff, 0.15)
+        .setScrollFactor(0).setDepth(HUD_DEPTH).setInteractive();
+      scene.add.text(padX + dx, padY + dy, label, {
+        fontSize: '16px', color: '#ffffff', resolution: 2,
+      }).setScrollFactor(0).setDepth(HUD_DEPTH + 1).setOrigin(0.5);
+
+      this.touchKeys[dir] = { isDown: false };
+      btn.on('pointerdown', () => { this.touchKeys[dir].isDown = true;  });
+      btn.on('pointerup',   () => { this.touchKeys[dir].isDown = false; });
+      btn.on('pointerout',  () => { this.touchKeys[dir].isDown = false; });
+    });
+
+    // Attack button (bottom-right)
+    const atkX = W - BTN - GAP;
+    const atkY = H - BTN - GAP;
+    const atkBtn = scene.add.rectangle(atkX, atkY, BTN, BTN, 0xff4400, 0.5)
+      .setScrollFactor(0).setDepth(HUD_DEPTH).setInteractive();
+    scene.add.text(atkX, atkY, '⚔', {
+      fontSize: '18px', color: '#ffffff', resolution: 2,
+    }).setScrollFactor(0).setDepth(HUD_DEPTH + 1).setOrigin(0.5);
+
+    this.touchKeys.attack = { isDown: false };
+    atkBtn.on('pointerdown', () => { this.touchKeys.attack.isDown = true;  });
+    atkBtn.on('pointerup',   () => { this.touchKeys.attack.isDown = false; });
+    atkBtn.on('pointerout',  () => { this.touchKeys.attack.isDown = false; });
+  }
+
+  update(gameData) {
+    const { hp, maxHp, xp, coins } = gameData;
+    const level = levelFromXp(xp);
+
+    // Hearts
+    this.hearts.forEach((h, i) => {
+      h.full.setVisible(i < hp);
+    });
+
+    // XP fill
+    const needed   = xpForLevel(level);
+    let   prevXp   = 0;
+    let   accum    = 0;
+    for (let l = 1; l < level; l++) {
+      prevXp += xpForLevel(l);
+    }
+    const progress = Math.min((xp - prevXp) / needed, 1);
+    this.xpFill.setCrop(0, 0, Math.floor(128 * progress), 8);
+    this.xpLabel.setText(`XP ${xp - prevXp}/${needed}`);
+    this.levelLabel.setText(`LV ${level}`);
+
+    // Coins
+    this.coinLabel.setText(String(coins));
+  }
+
+  showFloatingText(x, y, text, color = '#fcd860') {
+    const scene = this.scene;
+    const cam   = scene.cameras.main;
+    const sx    = x - cam.scrollX;
+    const sy    = y - cam.scrollY;
+
+    const label = scene.add.text(sx, sy, text, {
+      fontSize: '12px',
+      fontFamily: 'monospace',
+      color,
+      stroke: '#000000',
+      strokeThickness: 3,
+      resolution: 2,
+    }).setScrollFactor(0).setDepth(HUD_DEPTH + 10).setOrigin(0.5);
+
+    scene.tweens.add({
+      targets: label,
+      y: sy - 40,
+      alpha: 0,
+      duration: 1200,
+      ease: 'Power2',
+      onComplete: () => label.destroy(),
+    });
+  }
+}

--- a/frontend/src/pages/AdventureMode.jsx
+++ b/frontend/src/pages/AdventureMode.jsx
@@ -33,12 +33,24 @@ export default function AdventureMode() {
 
   const handleExit = useCallback(() => { navigate('/'); }, [navigate]);
 
+  // Lock body scroll while the full-screen overlay is active (mirrors Modal.jsx).
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = prev; };
+  }, []);
+
   useEffect(() => {
     if (!containerRef.current || !user) return;
-    let game = null;
+
+    // `cancelled` guards the race where React unmounts before the dynamic import
+    // resolves — without it the Phaser game created in the .then() callback would
+    // have no cleanup path and leak indefinitely.
+    let cancelled = false;
 
     import('../game/engine/GameInstance.js').then(({ createGame }) => {
-      game = createGame(containerRef.current.id, {
+      if (cancelled) return;
+      const game = createGame(containerRef.current.id, {
         userId:     String(user.id),
         userName:   user.username ?? user.display_name ?? 'Hero',
         headerH:    HEADER_H,
@@ -50,8 +62,10 @@ export default function AdventureMode() {
     });
 
     return () => {
+      cancelled = true;
       import('../game/engine/GameInstance.js').then(({ destroyGame }) => {
-        destroyGame(game);
+        destroyGame(gameRef.current);
+        gameRef.current = null;
       });
     };
   }, [user, handleExit, handleGameEvent]);

--- a/frontend/src/pages/AdventureMode.jsx
+++ b/frontend/src/pages/AdventureMode.jsx
@@ -31,7 +31,10 @@ export default function AdventureMode() {
       setActivePortal(event.zone);
       setGameData({ ...event.gameData });
       const scene = gameRef.current?.scene?.getScene('WorldScene');
-      if (scene) scene._paused = true;
+      if (scene) {
+        scene._paused = true;
+        scene.physics.pause(); // stop enemy movement + contact-damage overlaps
+      }
     }
   }, []);
 
@@ -84,7 +87,10 @@ export default function AdventureMode() {
   function closePortal() {
     setActivePortal(null);
     const scene = gameRef.current?.scene?.getScene('WorldScene');
-    if (scene) scene._paused = false;
+    if (scene) {
+      scene._paused = false;
+      scene.physics.resume(); // re-enable enemy movement + overlap detection
+    }
   }
 
   function handleChoreComplete({ assignment, xpGained, coinsGained }) {

--- a/frontend/src/pages/AdventureMode.jsx
+++ b/frontend/src/pages/AdventureMode.jsx
@@ -9,6 +9,10 @@ import { useAuth } from '../hooks/useAuth.jsx';
 import { QuestPortalOverlay } from '../game/chore-portals/QuestPortalOverlay.jsx';
 import { writeSave } from '../game/systems/SaveSystem.js';
 import { levelFromXp } from '../game/data/WorldData.js';
+// Eager import so destroyGame is available synchronously in the effect cleanup,
+// eliminating the dynamic-import race that could leave a game instance un-destroyed
+// when React StrictMode unmounts+remounts before the lazy import resolves.
+import { createGame, destroyGame } from '../game/engine/GameInstance.js';
 
 const HEADER_H = 34; // px — keep in sync with GameInstance height calc
 
@@ -33,40 +37,47 @@ export default function AdventureMode() {
 
   const handleExit = useCallback(() => { navigate('/'); }, [navigate]);
 
-  // Lock body scroll while the full-screen overlay is active (mirrors Modal.jsx).
+  // Full iOS-safe scroll lock — mirrors Modal.jsx to prevent page scrolling behind canvas.
   useEffect(() => {
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => { document.body.style.overflow = prev; };
+    const alreadyLocked = document.body.style.position === 'fixed';
+    const scrollY = alreadyLocked
+      ? -parseInt(document.body.style.top || '0', 10)
+      : window.scrollY;
+    if (!alreadyLocked) {
+      document.body.style.position = 'fixed';
+      document.body.style.top      = `-${scrollY}px`;
+      document.body.style.left     = '0';
+      document.body.style.right    = '0';
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.body.style.position = '';
+      document.body.style.top      = '';
+      document.body.style.left     = '';
+      document.body.style.right    = '';
+      document.body.style.overflow = '';
+      window.scrollTo(0, scrollY);
+    };
   }, []);
 
   useEffect(() => {
     if (!containerRef.current || !user) return;
 
-    // `cancelled` guards the race where React unmounts before the dynamic import
-    // resolves — without it the Phaser game created in the .then() callback would
-    // have no cleanup path and leak indefinitely.
-    let cancelled = false;
-
-    import('../game/engine/GameInstance.js').then(({ createGame }) => {
-      if (cancelled) return;
-      const game = createGame(containerRef.current.id, {
-        userId:     String(user.id),
-        userName:   user.username ?? user.display_name ?? 'Hero',
-        headerH:    HEADER_H,
-        onExit:     handleExit,
-        onComplete: handleGameEvent,
-      });
-      gameRef.current = game;
-      setGameReady(true);
+    const game = createGame(containerRef.current.id, {
+      userId:     String(user.id),
+      userName:   user.username ?? user.display_name ?? 'Hero',
+      headerH:    HEADER_H,
+      onExit:     handleExit,
+      onComplete: handleGameEvent,
     });
+    gameRef.current = game;
+    setGameReady(true);
 
+    // destroyGame is imported at the top level so this cleanup runs synchronously —
+    // no dynamic-import race when React StrictMode unmounts before a lazy import resolves.
     return () => {
-      cancelled = true;
-      import('../game/engine/GameInstance.js').then(({ destroyGame }) => {
-        destroyGame(gameRef.current);
-        gameRef.current = null;
-      });
+      destroyGame(gameRef.current);
+      gameRef.current = null;
     };
   }, [user, handleExit, handleGameEvent]);
 

--- a/frontend/src/pages/AdventureMode.jsx
+++ b/frontend/src/pages/AdventureMode.jsx
@@ -1,0 +1,161 @@
+// Adventure Mode page — mounts the Phaser game in a React container.
+// Rendered via createPortal to avoid Layout's overflow-x:clip affecting
+// position:fixed children (which would mis-place the Phaser canvas).
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth.jsx';
+import { QuestPortalOverlay } from '../game/chore-portals/QuestPortalOverlay.jsx';
+import { writeSave } from '../game/systems/SaveSystem.js';
+import { levelFromXp } from '../game/data/WorldData.js';
+
+const HEADER_H = 34; // px — keep in sync with GameInstance height calc
+
+export default function AdventureMode() {
+  const { user }     = useAuth();
+  const navigate     = useNavigate();
+  const containerRef = useRef(null);
+  const gameRef      = useRef(null);
+
+  const [activePortal, setActivePortal] = useState(null);
+  const [gameData, setGameData]         = useState(null);
+  const [gameReady, setGameReady]       = useState(false);
+
+  const handleGameEvent = useCallback((event) => {
+    if (event.type === 'portalEnter') {
+      setActivePortal(event.zone);
+      setGameData({ ...event.gameData });
+      const scene = gameRef.current?.scene?.getScene('WorldScene');
+      if (scene) scene._paused = true;
+    }
+  }, []);
+
+  const handleExit = useCallback(() => { navigate('/'); }, [navigate]);
+
+  useEffect(() => {
+    if (!containerRef.current || !user) return;
+    let game = null;
+
+    import('../game/engine/GameInstance.js').then(({ createGame }) => {
+      game = createGame(containerRef.current.id, {
+        userId:     String(user.id),
+        userName:   user.username ?? user.display_name ?? 'Hero',
+        headerH:    HEADER_H,
+        onExit:     handleExit,
+        onComplete: handleGameEvent,
+      });
+      gameRef.current = game;
+      setGameReady(true);
+    });
+
+    return () => {
+      import('../game/engine/GameInstance.js').then(({ destroyGame }) => {
+        destroyGame(game);
+      });
+    };
+  }, [user, handleExit, handleGameEvent]);
+
+  function closePortal() {
+    setActivePortal(null);
+    const scene = gameRef.current?.scene?.getScene('WorldScene');
+    if (scene) scene._paused = false;
+  }
+
+  function handleChoreComplete({ assignment, xpGained, coinsGained }) {
+    setGameData((prev) => {
+      if (!prev) return prev;
+      const next = { ...prev, xp: prev.xp + xpGained, coins: prev.coins + coinsGained };
+      writeSave({ ...next, userId: String(user.id) });
+      const scene = gameRef.current?.scene?.getScene('WorldScene');
+      if (scene) {
+        scene.gameData.xp    = next.xp;
+        scene.gameData.coins = next.coins;
+        scene.sfx?.playChoreComplete();
+        if (activePortal) {
+          const currentLevel = scene.gameData.portalRestoreLevels?.[activePortal.id] ?? 0;
+          const newLevel = Math.min(currentLevel + 1, 3);
+          scene.gameData.portalRestoreLevels[activePortal.id] = newLevel;
+          scene.portalMgr?.setRestoreLevel(activePortal.id, newLevel);
+          scene.hud?.showFloatingText(
+            scene.player?.x ?? 320, scene.player?.y ?? 240,
+            `+${xpGained} XP  +${coinsGained}¢`, '#fcd860',
+          );
+        }
+      }
+      return next;
+    });
+  }
+
+  const level = gameData ? levelFromXp(gameData.xp) : null;
+
+  // Render via portal so position:fixed is relative to the true viewport,
+  // not a Layout ancestor that has overflow-x:clip.
+  return createPortal(
+    <div style={{
+      position: 'fixed', inset: 0,
+      background: '#000',
+      display: 'flex', flexDirection: 'column',
+      alignItems: 'center',
+      zIndex: 9999,
+    }}>
+      {/* Header bar */}
+      <div style={{
+        width: '100%',
+        height: HEADER_H,
+        display: 'flex', alignItems: 'center', gap: 8,
+        padding: '0 8px',
+        background: '#121212',
+        borderBottom: '1px solid #2a2a2a',
+        fontFamily: 'monospace', fontSize: 10, color: '#888',
+        flexShrink: 0,
+      }}>
+        <span style={{ color: '#fcd860', fontWeight: 700 }}>⚔ Adventure Mode</span>
+        {level !== null && (
+          <span style={{ color: '#bcbcbc' }}>LV {level} · {gameData.coins} coins</span>
+        )}
+        <span style={{ marginLeft: 'auto', fontSize: 9, color: '#555' }}>
+          SPACE = attack · ESC = pause
+        </span>
+        <button
+          onClick={handleExit}
+          style={{
+            background: 'none', border: '1px solid #3a3a3a', borderRadius: 4,
+            color: '#888', padding: '2px 8px', fontFamily: 'monospace',
+            fontSize: 9, cursor: 'pointer',
+          }}
+        >Exit</button>
+      </div>
+
+      {/* Game canvas fills the remaining viewport */}
+      <div style={{ position: 'relative', flex: 1, width: '100%', minHeight: 0 }}>
+        <div
+          id="adventure-game-container"
+          ref={containerRef}
+          style={{ position: 'absolute', inset: 0 }}
+        />
+
+        {!gameReady && (
+          <div style={{
+            position: 'absolute', inset: 0,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            background: '#121212', color: '#fcd860',
+            fontFamily: 'monospace', fontSize: 14, zIndex: 10,
+          }}>
+            Loading Adventure Mode...
+          </div>
+        )}
+
+        {activePortal && (
+          <QuestPortalOverlay
+            zone={activePortal}
+            gameData={gameData}
+            onClose={closePortal}
+            onChoreComplete={handleChoreComplete}
+          />
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/pages/KidDashboard.jsx
+++ b/frontend/src/pages/KidDashboard.jsx
@@ -378,6 +378,14 @@ export default function KidDashboard() {
           <div className="flex items-center gap-3">
             <PointCounter value={user?.points_balance ?? 0} />
             <StreakDisplay streak={user?.current_streak ?? 0} />
+            <button
+              onClick={() => navigate('/adventure')}
+              className="game-btn game-btn-purple flex items-center gap-1.5 !py-1.5 !px-3 !text-xs"
+              title="Adventure Mode"
+            >
+              <Sword size={13} />
+              Adventure
+            </button>
           </div>
         </div>
 

--- a/scripts/audit-patterns.sh
+++ b/scripts/audit-patterns.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# audit-patterns.sh — grep for known dangerous code patterns
+# Run manually or in CI to catch regressions before they ship.
+# Exit code 0 = clean. Exit code 1 = hits found (review required).
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+HITS=0
+RED='\033[0;31m'
+YEL='\033[0;33m'
+GRN='\033[0;32m'
+NC='\033[0m'
+
+check() {
+    local label="$1"; local severity="$2"; local pattern="$3"; shift 3
+    local results
+    results=$(grep -rn --include="*.py" "$pattern" "$@" 2>/dev/null || true)
+    if [[ -n "$results" ]]; then
+        if [[ "$severity" == "ERROR" ]]; then
+            echo -e "${RED}[ERROR] $label${NC}"
+            HITS=$((HITS+1))
+        else
+            echo -e "${YEL}[WARN]  $label${NC}"
+        fi
+        echo "$results" | sed 's/^/        /'
+        echo
+    fi
+}
+
+echo "=== ChoreQuest pattern audit ==="
+echo
+
+# ── Timezone / day-boundary ──────────────────────────────────────────────────
+echo "── Timezone / day-boundary ──"
+
+check \
+    "UTC midnight used as day boundary (.replace(hour=0) on UTC now)" \
+    "ERROR" \
+    'datetime\.now(timezone\.utc)\.replace(hour=' \
+    backend/
+
+check \
+    "datetime.now(timezone.utc) passed into should_advance_rotation" \
+    "ERROR" \
+    'should_advance_rotation.*datetime\.now(timezone\.utc)' \
+    backend/
+
+check \
+    "Hardcoded timezone string (ZoneInfo literal)" \
+    "ERROR" \
+    "ZoneInfo('[A-Za-z]" \
+    backend/
+
+check \
+    "datetime.utcnow() — deprecated, always UTC" \
+    "WARN" \
+    'datetime\.utcnow()' \
+    backend/
+
+# ── Security ─────────────────────────────────────────────────────────────────
+echo "── Security ──"
+
+check \
+    "password_hash included in a schema/response model" \
+    "ERROR" \
+    'password_hash.*:.*str\|password_hash.*Field' \
+    backend/schemas.py backend/routers/
+
+check \
+    "Raw SQL string interpolation (f-string in execute)" \
+    "ERROR" \
+    'execute(f"' \
+    backend/
+
+check \
+    "User-supplied filename stored directly (not uuid)" \
+    "WARN" \
+    'filename.*request\|request.*filename' \
+    backend/routers/
+
+# ── Data integrity ────────────────────────────────────────────────────────────
+echo "── Data integrity ──"
+
+# Note: rotations.py line ~88 is a legitimate bounds-guard (reset if index >= len after
+# kid list shrinks). The only problematic case is in chores.py assign_chore where it
+# was unconditional — fixed in PR #121 with a kids_changed guard.
+check \
+    "current_index = 0 unconditional (should be guarded by kids_changed in chores.py)" \
+    "WARN" \
+    'current_index = 0' \
+    backend/routers/
+
+check \
+    "last_rotated = datetime.now unconditional in assign endpoint" \
+    "WARN" \
+    'last_rotated = datetime' \
+    backend/routers/chores.py
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo "────────────────────────────────"
+if [[ $HITS -eq 0 ]]; then
+    echo -e "${GRN}✓ No ERROR-level patterns found.${NC}"
+else
+    echo -e "${RED}✗ $HITS ERROR-level pattern(s) found — review before merging.${NC}"
+    exit 1
+fi

--- a/scripts/audit-patterns.sh
+++ b/scripts/audit-patterns.sh
@@ -24,7 +24,7 @@ check() {
         else
             echo -e "${YEL}[WARN]  $label${NC}"
         fi
-        echo "$results" | sed 's/^/        /'
+        while IFS= read -r line; do echo "        $line"; done <<< "$results"
         echo
     fi
 }

--- a/scripts/audit-patterns.sh
+++ b/scripts/audit-patterns.sh
@@ -42,9 +42,9 @@ check \
     backend/
 
 check \
-    "datetime.now(timezone.utc) passed into should_advance_rotation" \
-    "ERROR" \
-    'should_advance_rotation.*datetime\.now(timezone\.utc)' \
+    "should_advance_rotation called with 'now' — verify now is local time, NOT datetime.now(timezone.utc)" \
+    "WARN" \
+    'should_advance_rotation(.*\bnow\b' \
     backend/
 
 check \


### PR DESCRIPTION
## Summary

- **New `/adventure` route** — full in-browser 8-bit RPG built on Phaser 3.88, zero external assets (all sprites, tiles, music generated procedurally at runtime via Canvas API and Web Audio API)
- **5 portal zones** map to real chore categories; walking into a portal opens a React overlay listing actual assigned chores — completing one awards XP/coins back into the game
- **Combat system** — range-based melee (broom → 72 px sweep), damage numbers, red flash on hit, enemy AI (wander + chase), HP/respawn loop
- **IndexedDB save slots** per userId (level, xp, coins, position, portal progress, tutorialSeen)
- **NES-style audio** — procedural BGM loop + 8 SFX via Web Audio API (no files)

## Key files

| File | Role |
|---|---|
| `frontend/src/game/engine/GameInstance.js` | Phaser config + create/destroy lifecycle |
| `frontend/src/game/engine/WorldScene.js` | Main scene: input, combat, portals, HUD, save |
| `frontend/src/game/engine/BootScene.js` | Loads IndexedDB save, generates sprites, starts WorldScene |
| `frontend/src/game/sprites/SpriteGenerator.js` | All pixel-art tiles, player, enemies, UI — pure Canvas API |
| `frontend/src/game/systems/SoundSystem.js` | Web Audio NES BGM + SFX engine |
| `frontend/src/game/systems/BattleSystem.js` | Attack range checks, damage, defeat |
| `frontend/src/game/systems/SaveSystem.js` | IndexedDB read/write per userId |
| `frontend/src/game/chore-portals/QuestPortalOverlay.jsx` | React overlay shown on portal entry |
| `frontend/src/pages/AdventureMode.jsx` | Page component, React↔Phaser bridge |

## Technical notes

- Game renders via `createPortal(…, document.body)` so `position:fixed` children work correctly inside Layout's `overflow-x:clip` ancestor
- Phaser textures are uploaded with `scene.textures.createCanvas()` + `tex.refresh()` (synchronous) rather than `addImage(new Image())` (async race condition in WebGL)
- React StrictMode double-invoke guard in BootScene prevents crashed-game promise resolutions (`if (!this.sys?.game || this.sys.game.isDestroyed) return`)
- Animation duplicate guards (`if (!scene.anims.exists(key))`) prevent StrictMode double-registration errors
- Tree tile transparent corners replaced with explicit grass-colour pixels so the dark game background doesn't bleed through the tileset

## Test plan

- [ ] Navigate to `/adventure` as a kid user — game loads, tutorial overlay appears
- [ ] Dismiss tutorial with any key or "Let's go!" button; movement works (WASD / arrows)
- [ ] Walk into a portal zone — React overlay opens with chore list; game pauses
- [ ] Complete a chore in overlay — XP + coin numbers appear in HUD; portal tints green
- [ ] Close overlay — game resumes, player position preserved
- [ ] Press SPACE near a critter — red flash + damage number appears; enemy dies after 2-4 hits
- [ ] Let HP reach 0 — "You Fainted!" screen; respawn at center with 3 HP after 2.5 s
- [ ] Press ESC — pause menu appears; Resume/Exit both work
- [ ] Reload page — save is restored from IndexedDB (position, XP, coins preserved)
- [ ] Exit via header button — returns to main app

🤖 Generated with [Claude Code](https://claude.com/claude-code)