### PR TITLE
feat(adventure): Phase 1–4 art, UX and gameplay polish

### DIFF
--- a/frontend/src/game/chore-portals/PortalManager.js
+++ b/frontend/src/game/chore-portals/PortalManager.js
@@ -20,11 +20,13 @@ export class PortalManager {
       portal.setDepth(8);
       portal.body.setSize(TILE_SIZE * 1.5, TILE_SIZE * 1.5);
 
-      // Glow tint cycling
+      // Start at restore level 0 (dim grey, slow pulse)
+      // setRestoreLevel() updates this when save data is loaded.
+      portal.setTint(0x888888);
       this.scene.tweens.add({
         targets: portal,
-        alpha: 0.7,
-        duration: 800,
+        alpha: 0.3,
+        duration: 1800,
         yoyo: true,
         repeat: -1,
         ease: 'Sine.easeInOut',
@@ -77,12 +79,31 @@ export class PortalManager {
   }
 
   setRestoreLevel(zoneId, level) {
-    // Visually tint portal to show restoration progress
+    // Tint and scale portal to reflect restoration progress (0 = dim, 4 = fully restored)
     const child = this.portals.getChildren().find(
       (p) => p.zoneData.id === zoneId
     );
     if (!child) return;
-    const tints = [0xffffff, 0xaaffaa, 0x44ff44, 0x00cc00];
-    child.setTint(tints[Math.min(level, 3)]);
+
+    // Progressively brighter green tint
+    const tints = [0x888888, 0xaaffaa, 0x44ff44, 0x00cc00, 0x00ff88];
+    child.setTint(tints[Math.min(level, 4)]);
+
+    // Stop any running alpha tween and replace with level-appropriate pulse speed
+    this.scene.tweens.killTweensOf(child);
+    const pulseDuration = level === 0 ? 1800 : level < 3 ? 1200 : 600; // faster = healthier
+    const minAlpha      = level === 0 ? 0.3 : 0.55;
+    this.scene.tweens.add({
+      targets: child,
+      alpha: minAlpha,
+      duration: pulseDuration,
+      yoyo: true,
+      repeat: -1,
+      ease: 'Sine.easeInOut',
+    });
+
+    // Grow portal slightly as the zone restores (scale 1 → 1.4)
+    const scale = 1 + level * 0.1;
+    child.setScale(scale);
   }
 }

--- a/frontend/src/game/chore-portals/PortalManager.js
+++ b/frontend/src/game/chore-portals/PortalManager.js
@@ -102,8 +102,10 @@ export class PortalManager {
       ease: 'Sine.easeInOut',
     });
 
-    // Grow portal slightly as the zone restores (scale 1 → 1.4)
+    // Grow portal slightly as the zone restores (scale 1 → 1.4).
+    // refreshBody() keeps the static physics hitbox in sync with the new visual size.
     const scale = 1 + level * 0.1;
     child.setScale(scale);
+    child.refreshBody();
   }
 }

--- a/frontend/src/game/chore-portals/QuestPortalOverlay.jsx
+++ b/frontend/src/game/chore-portals/QuestPortalOverlay.jsx
@@ -29,18 +29,62 @@ function DifficultyBadge({ difficulty }) {
   );
 }
 
+// Starter broom card — shows as a greyed-out reference so players have a baseline
+const BROOM_CARD = { weapon: 'broom', name: 'Broom', desc: 'Your trusty starter weapon' };
+
 // ── Weapon Shop (shown inside the Reward Castle portal) ───────────────────────
 function WeaponShop({ gameData, onBuyWeapon, onEquipWeapon }) {
   const owned    = gameData?.unlockedWeapons ?? ['broom'];
   const equipped = gameData?.weapon ?? 'broom';
   const coins    = gameData?.coins ?? 0;
 
+  // Prepend the broom as a non-purchasable starter card for context
+  const allCards = [{ ...BROOM_CARD, isStarter: true }, ...WEAPON_UPGRADES];
+
   return (
     <div>
       <div style={{ fontSize: 9, color: '#888', marginBottom: 10 }}>
         Your coins: <strong style={{ color: '#fcd860' }}>{coins}</strong>
       </div>
-      {WEAPON_UPGRADES.map((u) => {
+      {allCards.map((u) => {
+        if (u.isStarter) {
+          // Broom starter card — always owned, just show equip/equipped state
+          const isEquipped = equipped === 'broom';
+          const { damage, range } = WEAPON_STATS['broom'] ?? {};
+          return (
+            <div key="broom" style={{
+              background: isEquipped ? '#1a2a1a' : '#1e1e1e',
+              border: `1px solid ${isEquipped ? '#58d854' : '#2a2a2a'}`,
+              borderRadius: 6, padding: '10px 12px', marginBottom: 8,
+            }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 12, color: '#999', fontWeight: 600 }}>
+                    {u.name}
+                    <span style={{ marginLeft: 6, fontSize: 9, color: '#555' }}>STARTER</span>
+                    {isEquipped && <span style={{ marginLeft: 6, fontSize: 9, color: '#58d854' }}>✓ EQUIPPED</span>}
+                  </div>
+                  <div style={{ fontSize: 9, color: '#555', marginTop: 2 }}>{u.desc}</div>
+                  <div style={{ fontSize: 9, color: '#666', marginTop: 2 }}>
+                    <span style={{ color: '#c04040' }}>DMG {damage}</span>
+                    {' · '}
+                    <span style={{ color: '#4458c8' }}>RNG {range}</span>
+                  </div>
+                </div>
+              </div>
+              {!isEquipped && (
+                <button
+                  onClick={() => onEquipWeapon({ weapon: 'broom' })}
+                  style={{
+                    padding: '5px 12px', background: '#334433', border: '1px solid #58d854',
+                    borderRadius: 4, color: '#58d854', fontFamily: 'monospace',
+                    fontSize: 10, cursor: 'pointer', fontWeight: 700,
+                  }}
+                >Equip</button>
+              )}
+            </div>
+          );
+        }
         const isOwned    = owned.includes(u.weapon);
         const isEquipped = equipped === u.weapon;
         const canAfford  = coins >= u.cost;
@@ -209,6 +253,20 @@ export function QuestPortalOverlay({ zone, gameData, onClose, onChoreComplete, o
           <div>
             <div style={{ fontSize: 14, color: '#fcd860', fontWeight: 700 }}>{zone.label}</div>
             <div style={{ fontSize: 9, color: '#888' }}>{zone.description}</div>
+            {!zone.isRewardShop && (() => {
+              const lvl = gameData?.portalRestoreLevels?.[zone.id] ?? 0;
+              return (
+                <div style={{ marginTop: 3, fontSize: 9, color: '#888', display: 'flex', alignItems: 'center', gap: 3 }}>
+                  <span style={{ color: '#666' }}>Zone health:</span>
+                  {[0,1,2,3].map(i => (
+                    <span key={i} style={{ color: i < lvl ? '#58d854' : '#333', fontSize: 11 }}>◆</span>
+                  ))}
+                  <span style={{ color: '#555', fontSize: 8, marginLeft: 2 }}>
+                    {lvl === 0 ? '(complete chores to restore!)' : lvl < 4 ? `(${lvl}/4 restored)` : '(fully restored!)'}
+                  </span>
+                </div>
+              );
+            })()}
           </div>
           <button
             onClick={onClose}

--- a/frontend/src/game/chore-portals/QuestPortalOverlay.jsx
+++ b/frontend/src/game/chore-portals/QuestPortalOverlay.jsx
@@ -32,6 +32,24 @@ function DifficultyBadge({ difficulty }) {
 // Starter broom card — shows as a greyed-out reference so players have a baseline
 const BROOM_CARD = { weapon: 'broom', name: 'Broom', desc: 'Your trusty starter weapon' };
 
+// Stat bar — renders a mini progress bar for damage or range comparisons
+function StatBar({ label, value, max, color }) {
+  const pct = Math.min(value / max, 1);
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 2 }}>
+      <span style={{ fontSize: 8, color: '#666', minWidth: 24 }}>{label}</span>
+      <div style={{ width: 48, height: 4, background: '#1a1a1a', borderRadius: 2, position: 'relative' }}>
+        <div style={{
+          width: `${pct * 100}%`, height: '100%',
+          background: color, borderRadius: 2,
+          minWidth: pct > 0 ? 2 : 0,
+        }} />
+      </div>
+      <span style={{ fontSize: 8, color }}>{value}</span>
+    </div>
+  );
+}
+
 // ── Weapon Shop (shown inside the Reward Castle portal) ───────────────────────
 function WeaponShop({ gameData, onBuyWeapon, onEquipWeapon }) {
   const owned    = gameData?.unlockedWeapons ?? ['broom'];
@@ -65,11 +83,8 @@ function WeaponShop({ gameData, onBuyWeapon, onEquipWeapon }) {
                     {isEquipped && <span style={{ marginLeft: 6, fontSize: 9, color: '#58d854' }}>✓ EQUIPPED</span>}
                   </div>
                   <div style={{ fontSize: 9, color: '#555', marginTop: 2 }}>{u.desc}</div>
-                  <div style={{ fontSize: 9, color: '#666', marginTop: 2 }}>
-                    <span style={{ color: '#c04040' }}>DMG {damage}</span>
-                    {' · '}
-                    <span style={{ color: '#4458c8' }}>RNG {range}</span>
-                  </div>
+                  <StatBar label="DMG" value={damage} max={5}   color="#f87858" />
+                  <StatBar label="RNG" value={range}  max={120} color="#6888fc" />
                 </div>
               </div>
               {!isEquipped && (
@@ -105,11 +120,8 @@ function WeaponShop({ gameData, onBuyWeapon, onEquipWeapon }) {
                   )}
                 </div>
                 <div style={{ fontSize: 9, color: '#666', marginTop: 2 }}>{u.desc}</div>
-                <div style={{ fontSize: 9, color: '#888', marginTop: 2 }}>
-                  <span style={{ color: '#f87858' }}>DMG {stats.damage}</span>
-                  {' · '}
-                  <span style={{ color: '#6888fc' }}>RNG {stats.range}</span>
-                </div>
+                <StatBar label="DMG" value={stats.damage} max={5}   color="#f87858" />
+                <StatBar label="RNG" value={stats.range}  max={120} color="#6888fc" />
               </div>
               {!isOwned && (
                 <span style={{ fontSize: 11, color: '#fcd860', fontWeight: 700 }}>

--- a/frontend/src/game/engine/WorldScene.js
+++ b/frontend/src/game/engine/WorldScene.js
@@ -2,7 +2,7 @@
 
 import Phaser from 'phaser';
 import { buildWorldTilemap }     from '../maps/WorldMap.js';
-import { createPlayer, updatePlayer, PLAYER_SPEED } from '../entities/Player.js';
+import { createPlayer, updatePlayer, playAttackAnim, PLAYER_SPEED } from '../entities/Player.js';
 import { createEnemyAnimations, spawnEnemy, updateEnemy } from '../entities/Enemy.js';
 import { PortalManager }         from '../chore-portals/PortalManager.js';
 import { BattleSystem }          from '../systems/BattleSystem.js';
@@ -124,7 +124,8 @@ export class WorldScene extends Phaser.Scene {
     });
 
     this.events.on('comboHit', ({ multiplier }) => {
-      this.hud.showFloatingText(
+      this.hud.showCombo(multiplier);    // persistent HUD counter
+      this.hud.showFloatingText(         // floating pop for immediate impact
         this.player.x, this.player.y - 48,
         `${multiplier}× COMBO!`,
         multiplier >= 3 ? '#ff4444' : '#ff8800',
@@ -214,6 +215,7 @@ export class WorldScene extends Phaser.Scene {
       this.battle.playerAttack(this.player.weapon, this.enemies, this.player);
       this._spawnAttackVfx();
       this.sfx.playAttack();
+      playAttackAnim(this, this.player, 180); // show directional swing frame
     }
 
     // Level-up detection
@@ -228,6 +230,7 @@ export class WorldScene extends Phaser.Scene {
     const phase      = ((this.time.now - this._cycleStart) % CYCLE_MS) / CYCLE_MS;
     const nightAlpha = 0.55 * 0.5 * (1 - Math.cos(2 * Math.PI * phase));
     this._nightOverlay.setAlpha(nightAlpha);
+    this.hud.updateNightCycle(nightAlpha);
     // Enemies get up to 30% faster at peak night
     const nightBoost = 1 + nightAlpha * 0.55;
 
@@ -262,27 +265,89 @@ export class WorldScene extends Phaser.Scene {
   }
 
   _spawnAttackVfx() {
-    // A wider, brighter sweep that makes it obvious you swung
+    const weapon  = this.player.weapon ?? 'broom';
+    const facing  = this.player.facing ?? 'down';
     const offsets = { down: [0, 32], up: [0, -32], left: [-32, 0], right: [32, 0] };
-    const [ox, oy] = offsets[this.player.facing] ?? [0, 32];
-    const isHoriz  = (this.player.facing === 'left' || this.player.facing === 'right');
+    const [ox, oy] = offsets[facing] ?? [0, 32];
+    const isHoriz  = (facing === 'left' || facing === 'right');
+    const px = this.player.x + ox;
+    const py = this.player.y + oy;
 
-    // Sweep rectangle — elongated in the perpendicular direction
+    if (weapon === 'broom') {
+      // Diagonal slash arc: two crossing rectangles in NES yellow
+      const ang = isHoriz ? 0 : Math.PI / 2;
+      const vfx1 = this.add.rectangle(px, py, 40, 8, 0xfcd860, 0.9)
+        .setDepth(12).setRotation(ang + Math.PI / 4);
+      const vfx2 = this.add.rectangle(px, py, 40, 8, 0xfcd860, 0.9)
+        .setDepth(12).setRotation(ang - Math.PI / 4);
+      [vfx1, vfx2].forEach((v) => {
+        this.tweens.add({
+          targets: v, alpha: 0, scaleX: 1.6, scaleY: 1.6,
+          duration: 180, ease: 'Power2', onComplete: () => v.destroy(),
+        });
+      });
+      return;
+    }
+
+    if (weapon === 'vacuum') {
+      // Rectangular "blast" beam extending from player in facing direction
+      const vfx = this.add.rectangle(
+        px, py,
+        isHoriz ? 48 : 28, isHoriz ? 28 : 48,
+        0x6888fc, 0.80
+      ).setDepth(12);
+      this.tweens.add({
+        targets: vfx, alpha: 0, scaleX: 2, scaleY: 2,
+        duration: 220, ease: 'Power1', onComplete: () => vfx.destroy(),
+      });
+      return;
+    }
+
+    if (weapon === 'soap') {
+      // Splatter: 5 small orange droplets radiating outward
+      for (let i = 0; i < 5; i++) {
+        const baseAngle = Math.atan2(oy, ox);
+        const spread    = (Math.PI / 3);
+        const a         = baseAngle + (i - 2) * (spread / 4);
+        const drop      = this.add.rectangle(
+          this.player.x, this.player.y, 6, 6, 0xfc7820, 0.9,
+        ).setDepth(12);
+        this.tweens.add({
+          targets: drop,
+          x: this.player.x + Math.cos(a) * 36,
+          y: this.player.y + Math.sin(a) * 36,
+          alpha: 0, scaleX: 0.3, scaleY: 0.3,
+          duration: 200, ease: 'Power1', onComplete: () => drop.destroy(),
+        });
+      }
+      return;
+    }
+
+    if (weapon === 'sponge') {
+      // Radial burst — ring of 8 white squares expanding outward
+      for (let i = 0; i < 8; i++) {
+        const a    = (Math.PI * 2 * i) / 8;
+        const puff = this.add.rectangle(
+          this.player.x, this.player.y, 8, 8, 0xfcfcfc, 0.85,
+        ).setDepth(12);
+        this.tweens.add({
+          targets: puff,
+          x: this.player.x + Math.cos(a) * 56,
+          y: this.player.y + Math.sin(a) * 56,
+          alpha: 0, scaleX: 0.5, scaleY: 0.5,
+          duration: 280, ease: 'Power2', onComplete: () => puff.destroy(),
+        });
+      }
+      return;
+    }
+
+    // Fallback: original white sweep
     const vfx = this.add.rectangle(
-      this.player.x + ox, this.player.y + oy,
-      isHoriz ? 24 : 48,   // width
-      isHoriz ? 48 : 24,   // height
-      0xffffff, 0.85
+      px, py, isHoriz ? 24 : 48, isHoriz ? 48 : 24, 0xffffff, 0.85,
     ).setDepth(12);
-
     this.tweens.add({
-      targets: vfx,
-      alpha: 0,
-      scaleX: 1.8,
-      scaleY: 1.8,
-      duration: 180,
-      ease: 'Power2',
-      onComplete: () => vfx.destroy(),
+      targets: vfx, alpha: 0, scaleX: 1.8, scaleY: 1.8,
+      duration: 180, ease: 'Power2', onComplete: () => vfx.destroy(),
     });
   }
 

--- a/frontend/src/game/engine/WorldScene.js
+++ b/frontend/src/game/engine/WorldScene.js
@@ -381,18 +381,54 @@ export class WorldScene extends Phaser.Scene {
   _handlePlayerDeath() {
     this.player.isAlive = false;
     this.player.body.setVelocity(0, 0);
+    this.physics.pause();
 
     const w = this.scale.width;
     const h = this.scale.height;
-    this.add.rectangle(w / 2, h / 2, w, h, 0x000000, 0.6)
-      .setScrollFactor(0).setDepth(200);
-    this.add.text(w / 2, h / 2 - 16, 'You Fainted!', {
-      fontSize: '20px', fontFamily: 'monospace', color: '#ff4444',
-      stroke: '#000', strokeThickness: 4, resolution: 2,
-    }).setScrollFactor(0).setDepth(201).setOrigin(0.5);
 
-    this.time.delayedCall(2500, () => {
-      // Respawn: restore 3 HP
+    // 1. Player sprite: spin + shrink to nothing
+    this.tweens.add({
+      targets: this.player,
+      angle: 360,
+      scaleX: 0, scaleY: 0,
+      alpha: 0,
+      duration: 600,
+      ease: 'Power2',
+    });
+
+    // 2. Screen darkens gradually after the sprite finishes
+    const overlay = this.add.rectangle(w / 2, h / 2, w, h, 0x000000, 0)
+      .setScrollFactor(0).setDepth(200);
+    this.tweens.add({
+      targets: overlay, alpha: 0.75,
+      delay: 400, duration: 500, ease: 'Power1',
+    });
+
+    // 3. "YOU FAINTED" slides down from above with a bounce
+    const faintTxt = this.add.text(w / 2, h / 2 - h * 0.4, 'YOU FAINTED', {
+      fontSize: '22px', fontFamily: 'monospace', color: '#ff4444',
+      stroke: '#000', strokeThickness: 5, resolution: 2,
+    }).setScrollFactor(0).setDepth(201).setOrigin(0.5).setAlpha(0);
+    this.tweens.add({
+      targets: faintTxt,
+      y: h / 2 - 20,
+      alpha: 1,
+      delay: 700,
+      duration: 400,
+      ease: 'Bounce.easeOut',
+    });
+
+    // 4. Respawn sub-text fades in below
+    const respawnTxt = this.add.text(w / 2, h / 2 + 20, 'Respawning with 3 hearts...', {
+      fontSize: '9px', fontFamily: 'monospace', color: '#888888',
+      stroke: '#000', strokeThickness: 2, resolution: 2,
+    }).setScrollFactor(0).setDepth(201).setOrigin(0.5).setAlpha(0);
+    this.tweens.add({
+      targets: respawnTxt, alpha: 1,
+      delay: 1200, duration: 300,
+    });
+
+    this.time.delayedCall(2800, () => {
       this.gameData.hp = Math.min(3, this.gameData.maxHp);
       this.gameData.playerX = 640;
       this.gameData.playerY = 640;
@@ -400,6 +436,7 @@ export class WorldScene extends Phaser.Scene {
         userId: this.userId, userName: this.userName,
         gameData: this.gameData, tileMap: this.tileMap,
         onExit: this.onExit, onComplete: this.onComplete,
+        isKid: this.isKid,
       });
     });
   }
@@ -453,74 +490,133 @@ export class WorldScene extends Phaser.Scene {
     this._paused = true;
     this.physics.pause();
 
-    const w = this.scale.width;
-    const h = this.scale.height;
+    const w  = this.scale.width;
+    const h  = this.scale.height;
     const cx = w / 2;
     const cy = h / 2;
 
-    const panelW = Math.min(w - 32, 340);
-    const panelH = 310;
+    // Panel dimensions — wider and taller than the original for legibility
+    const panelW = Math.min(w - 20, 440);
+    const isTouch = this.sys.game.device.input.touch;
+    // Compute panel height from content so nothing is clipped on small screens
+    const TITLE_H   = 56;  // title + subtitle + divider
+    const GRID_ROWS = 3;
+    const ROW_H     = 54;
+    const TOUCH_H   = isTouch ? 28 : 0;
+    const BTN_H     = 54;  // divider + button + sub-label
+    const VPAD      = 20;  // top + bottom padding
+    const panelH    = Math.min(h - 16, TITLE_H + GRID_ROWS * ROW_H + TOUCH_H + BTN_H + VPAD * 2);
+    const top       = cy - panelH / 2;
 
     const container = this.add.container(0, 0).setScrollFactor(0).setDepth(400);
 
-    // ── Background layers (added first = rendered behind) ─────────────
-    const dim   = this.add.rectangle(cx, cy, w, h, 0x000000, 0.75);
-    const panel = this.add.rectangle(cx, cy, panelW, panelH, 0x1a1a2e, 1)
-                    .setStrokeStyle(2, 0xfcd860);
-    container.add([dim, panel]);
+    // ── Backdrop + panel ──────────────────────────────────────────────
+    const dim   = this.add.rectangle(cx, cy, w, h, 0x000000, 0.82);
+    const panel = this.add.rectangle(cx, cy, panelW, panelH, 0x0d0d1e, 1)
+      .setStrokeStyle(2, 0xfcd860);
+    // NES-style corner accent dots
+    const cornerOffsets = [
+      [-panelW / 2 + 5,  -panelH / 2 + 5],
+      [ panelW / 2 - 5,  -panelH / 2 + 5],
+      [-panelW / 2 + 5,   panelH / 2 - 5],
+      [ panelW / 2 - 5,   panelH / 2 - 5],
+    ];
+    const corners = cornerOffsets.map(([ox, oy]) =>
+      this.add.rectangle(cx + ox, cy + oy, 4, 4, 0xfcd860)
+    );
+    container.add([dim, panel, ...corners]);
 
-    // ── Title + divider ───────────────────────────────────────────────
-    const title = this.add.text(cx, cy - panelH / 2 + 22, '-- HOW TO PLAY --', {
-      fontSize: '11px', fontFamily: 'monospace', color: '#fcd860',
-      stroke: '#000', strokeThickness: 3, resolution: 2,
-    }).setOrigin(0.5);
-    const divLine = this.add.rectangle(cx, cy - panelH / 2 + 38, panelW - 24, 1, 0x3a3a5a);
-    container.add([title, divLine]);
+    // ── Title block ───────────────────────────────────────────────────
+    const titleY = top + VPAD + 14;
+    const titleTxt = this.add.text(cx, titleY,
+      '⚔  ADVENTURE MODE  ⚔', {
+        fontSize: '13px', fontFamily: 'monospace', color: '#fcd860',
+        stroke: '#000', strokeThickness: 3, resolution: 2,
+      }).setOrigin(0.5);
+    const subTxt = this.add.text(cx, titleY + 18,
+      'Complete chores  ›  earn XP & coins  ›  level up!', {
+        fontSize: '8px', fontFamily: 'monospace', color: '#666688',
+        stroke: '#000', strokeThickness: 2, resolution: 2,
+      }).setOrigin(0.5);
+    const divTop = this.add.rectangle(cx, titleY + 32, panelW - 28, 1, 0x2a2a4a);
+    container.add([titleTxt, subTxt, divTop]);
 
-    // ── Control rows ─────────────────────────────────────────────────
-    // [bullet, label, description]
-    const rows = [
-      ['>>', 'MOVE',    'Arrow keys  or  W  A  S  D'],
-      ['>>',  'ATTACK',  'SPACE  (broom swing)'],
-      ['>>',  'PORTALS', 'Walk into glowing orbs\nto open chore quests'],
-      ['>>',  'ENEMIES', 'Attack critters for XP & coins'],
-      ['>>',  'PAUSE',   'ESC  key'],
+    // ── Controls grid (2 columns × 3 rows) ───────────────────────────
+    // Each entry: [col, icon, action, keyHint, description, accentColor]
+    const controls = [
+      [0, '◈', 'MOVE',    '[ ↑↓←→ ]  or  [ W A S D ]', 'Walk around the Home Realm',       '#6888fc'],
+      [0, '◉', 'PORTALS', 'Walk into a glowing portal',  'Opens your chore quest list',       '#58d854'],
+      [0, '▸', 'PAUSE',   '[ ESC ]',                     'Pause or open the menu',            '#bcbcbc'],
+      [1, '✦', 'ATTACK',  '[ SPACE ]',                   'Swing your weapon at enemies',      '#fca044'],
+      [1, '◎', 'COINS',   'Defeat enemies + do chores',  'Spend at the Reward Castle  ★',    '#fcd860'],
+      [1, '⚔', 'WEAPONS', 'Visit the Reward Castle',     'Buy upgrades with your coins',      '#f87858'],
     ];
 
-    const rowStartY = cy - panelH / 2 + 60;
-    const rowStep   = 44;
-    const lx = cx - panelW / 2 + 18; // left edge of text
+    const gridTop  = top + TITLE_H + VPAD;
+    const colLx    = cx - panelW / 2 + 16;
+    const colRx    = cx + 4;
 
-    rows.forEach(([, label, desc], i) => {
-      const ry = rowStartY + i * rowStep;
+    controls.forEach(([col, icon, action, key, desc, color], idx) => {
+      const row = idx % GRID_ROWS;   // 0–2
+      const lx  = col === 0 ? colLx : colRx;
+      const ry  = gridTop + row * ROW_H;
 
-      const bullet = this.add.text(lx, ry, '>>', {
-        fontSize: '8px', fontFamily: 'monospace', color: '#fcd860',
-        stroke: '#000', strokeThickness: 2, resolution: 2,
+      const iconT = this.add.text(lx, ry + 10, icon, {
+        fontSize: '15px', fontFamily: 'monospace', color,
+        stroke: '#000', strokeThickness: 3, resolution: 2,
       }).setOrigin(0, 0.5);
 
-      const labelTxt = this.add.text(lx + 20, ry, label, {
-        fontSize: '9px', fontFamily: 'monospace', color: '#ffffff',
+      const actT = this.add.text(lx + 22, ry + 1, action, {
+        fontSize: '10px', fontFamily: 'monospace', color: '#e5e5e5',
         stroke: '#000', strokeThickness: 2, resolution: 2,
-      }).setOrigin(0, 0.5);
-
-      const descTxt = this.add.text(lx + 20, ry + 14, desc, {
-        fontSize: '7px', fontFamily: 'monospace', color: '#aaaaaa',
-        stroke: '#000', strokeThickness: 2, resolution: 2, lineSpacing: 3,
       }).setOrigin(0, 0);
 
-      container.add([bullet, labelTxt, descTxt]);
+      const keyT = this.add.text(lx + 22, ry + 16, key, {
+        fontSize: '8px', fontFamily: 'monospace', color,
+        stroke: '#000', strokeThickness: 2, resolution: 2,
+      }).setOrigin(0, 0);
+
+      const descT = this.add.text(lx + 22, ry + 30, desc, {
+        fontSize: '7px', fontFamily: 'monospace', color: '#777799',
+        stroke: '#000', strokeThickness: 1, resolution: 2,
+      }).setOrigin(0, 0);
+
+      container.add([iconT, actT, keyT, descT]);
     });
 
-    // ── "Let's go!" button ────────────────────────────────────────────
-    const btnY  = cy + panelH / 2 - 26;
-    const btnBg = this.add.rectangle(cx, btnY, 150, 28, 0xfcd860)
+    // Column divider line (between the two columns)
+    const colDiv = this.add.rectangle(cx - 2, gridTop + (GRID_ROWS * ROW_H) / 2,
+      1, GRID_ROWS * ROW_H - 8, 0x2a2a4a);
+    container.add([colDiv]);
+
+    // ── Touch controls hint (only on touch devices) ───────────────────
+    let touchBottom = gridTop + GRID_ROWS * ROW_H;
+    if (isTouch) {
+      const touchDivY = touchBottom + 4;
+      const touchDiv  = this.add.rectangle(cx, touchDivY, panelW - 28, 1, 0x2a2a4a);
+      const touchTxt  = this.add.text(cx, touchDivY + 14,
+        '📱  Joystick (bottom-left)   +   ⚔ button (bottom-right)', {
+          fontSize: '7px', fontFamily: 'monospace', color: '#555577',
+          stroke: '#000', strokeThickness: 2, resolution: 2,
+        }).setOrigin(0.5);
+      container.add([touchDiv, touchTxt]);
+      touchBottom += TOUCH_H;
+    }
+
+    // ── Dismiss button ────────────────────────────────────────────────
+    const btnDivY = touchBottom + 8;
+    const btnDiv  = this.add.rectangle(cx, btnDivY, panelW - 28, 1, 0x2a2a4a);
+    const btnY    = btnDivY + 22;
+    const btnBg   = this.add.rectangle(cx, btnY, panelW - 56, 28, 0xfcd860)
       .setInteractive({ useHandCursor: true });
-    const btnTxt = this.add.text(cx, btnY, "Let's go!  (or press any key)", {
-      fontSize: '8px', fontFamily: 'monospace', color: '#1a1a2e',
-      resolution: 2,
+    const btnTxt  = this.add.text(cx, btnY, '►  LET\'S GO!  ◄', {
+      fontSize: '12px', fontFamily: 'monospace', color: '#0d0d1e',
+      stroke: '#000000', strokeThickness: 1, resolution: 2,
     }).setOrigin(0.5);
-    container.add([btnBg, btnTxt]);
+    const btnSub  = this.add.text(cx, btnY + 20, 'or press any key', {
+      fontSize: '7px', fontFamily: 'monospace', color: '#555555', resolution: 2,
+    }).setOrigin(0.5);
+    container.add([btnDiv, btnBg, btnTxt, btnSub]);
 
     // ── Dismiss logic ─────────────────────────────────────────────────
     const dismiss = () => {
@@ -536,6 +632,13 @@ export class WorldScene extends Phaser.Scene {
     btnBg.on('pointerover',  () => btnBg.setFillStyle(0xffe080));
     btnBg.on('pointerout',   () => btnBg.setFillStyle(0xfcd860));
     this.input.keyboard.once('keydown', dismiss);
+
+    // Panel slides in from below for a polished entrance
+    container.setAlpha(0).setY(30);
+    this.tweens.add({
+      targets: container, alpha: 1, y: 0,
+      duration: 280, ease: 'Power2',
+    });
   }
 
   _exitGame() {

--- a/frontend/src/game/entities/Enemy.js
+++ b/frontend/src/game/entities/Enemy.js
@@ -122,10 +122,9 @@ export function updateEnemy(enemy, playerSprite, delta) {
         enemy._chargeState = 'charging';
         enemy._chargeDur   = 450;
         const nd = dist || 1;
-        // Lint Titan burst uses enhanced speed
-        const chargeSpeedMult = (enemy.enemyType === 'lint_titan') ? 4 : 3;
-        enemy._chargeVx = (dx / nd) * enemy.baseSpeed * chargeSpeedMult;
-        enemy._chargeVy = (dy / nd) * enemy.baseSpeed * chargeSpeedMult;
+        const chargeSpeed = enemy._burstSpeed ?? (enemy.baseSpeed * 3);
+        enemy._chargeVx = (dx / nd) * chargeSpeed;
+        enemy._chargeVy = (dy / nd) * chargeSpeed;
         enemy.clearTint();
       }
       return;
@@ -137,14 +136,16 @@ export function updateEnemy(enemy, playerSprite, delta) {
         enemy._hasTeleported = true;
         // Fade out → reposition near player → fade in
         const scene = enemy.scene;
+        const uiParts = [enemy._hpBarBg, enemy._hpBarFill, enemy._nameTag].filter(Boolean);
         enemy.setAlpha(0);
+        uiParts.forEach((part) => part.setAlpha(0));
         // Pick a position 80–140px away from the player at a random angle
         const teleportAngle = Math.random() * Math.PI * 2;
         const teleportDist  = 80 + Math.random() * 60;
         const tx = playerSprite.x + Math.cos(teleportAngle) * teleportDist;
         const ty = playerSprite.y + Math.sin(teleportAngle) * teleportDist;
         enemy.setPosition(tx, ty);
-        scene.tweens.add({ targets: enemy, alpha: 1, duration: 300 });
+        scene.tweens.add({ targets: [enemy, ...uiParts], alpha: 1, duration: 300 });
         scene.sfx?.playBossWarning?.();
       }
     }
@@ -155,7 +156,7 @@ export function updateEnemy(enemy, playerSprite, delta) {
       if (enemy._chargeTimer <= 0) {
         enemy._chargeState = 'windup';
         // Lint Titan has a longer, more dramatic root wind-up
-        enemy._windupDur = (enemy.enemyType === 'lint_titan') ? 700 : 350;
+        enemy._windupDur = enemy._rootDur ?? 350;
         enemy.setTint(0xffff00); // yellow flash = warning
         enemy.scene?.sfx?.playBossWarning?.();
       }

--- a/frontend/src/game/entities/Enemy.js
+++ b/frontend/src/game/entities/Enemy.js
@@ -122,10 +122,13 @@ export function updateEnemy(enemy, playerSprite, delta) {
         enemy._chargeState = 'charging';
         enemy._chargeDur   = 450;
         const nd = dist || 1;
+        // Lint Titan uses its pre-set _burstSpeed; other bosses multiply base speed
         const chargeSpeed = enemy._burstSpeed ?? (enemy.baseSpeed * 3);
         enemy._chargeVx = (dx / nd) * chargeSpeed;
         enemy._chargeVy = (dy / nd) * chargeSpeed;
-        enemy.clearTint();
+        // Orange tint during the actual dash — stays until charge ends so player
+        // can still see the danger window
+        enemy.setTint(0xff8800);
       }
       return;
     }

--- a/frontend/src/game/entities/Enemy.js
+++ b/frontend/src/game/entities/Enemy.js
@@ -50,8 +50,9 @@ export function spawnEnemy(scene, type, x, y, isBoss = false) {
 
     // Type-specific behaviour flags
     if (type === 'lint_titan') {
-      // Lint Titan: root-and-burst — freezes briefly then lunges at double speed
-      enemy._burstSpeed    = stats.speed * 2.4;
+      // Lint Titan: long root wind-up (600 ms) then a fast 3.5× burst lunge.
+      // Using _burstSpeed so the charge logic in updateEnemy reads it automatically.
+      enemy._burstSpeed    = stats.speed * 3.5;
       enemy._rootDur       = 600; // ms frozen during wind-up
     }
     if (type === 'paper_wraith') {
@@ -142,11 +143,20 @@ export function updateEnemy(enemy, playerSprite, delta) {
         const uiParts = [enemy._hpBarBg, enemy._hpBarFill, enemy._nameTag].filter(Boolean);
         enemy.setAlpha(0);
         uiParts.forEach((part) => part.setAlpha(0));
-        // Pick a position 80–140px away from the player at a random angle
+        // Pick a position 80–140px away from the player at a random angle,
+        // clamped to world bounds so the boss never lands outside the map.
         const teleportAngle = Math.random() * Math.PI * 2;
         const teleportDist  = 80 + Math.random() * 60;
-        const tx = playerSprite.x + Math.cos(teleportAngle) * teleportDist;
-        const ty = playerSprite.y + Math.sin(teleportAngle) * teleportDist;
+        const bounds = scene.physics.world.bounds;
+        const margin = 32; // keep the boss sprite inside the visible area
+        const tx = Phaser.Math.Clamp(
+          playerSprite.x + Math.cos(teleportAngle) * teleportDist,
+          bounds.x + margin, bounds.right  - margin,
+        );
+        const ty = Phaser.Math.Clamp(
+          playerSprite.y + Math.sin(teleportAngle) * teleportDist,
+          bounds.y + margin, bounds.bottom - margin,
+        );
         enemy.setPosition(tx, ty);
         scene.tweens.add({ targets: [enemy, ...uiParts], alpha: 1, duration: 300 });
         scene.sfx?.playBossWarning?.();

--- a/frontend/src/game/entities/Enemy.js
+++ b/frontend/src/game/entities/Enemy.js
@@ -38,9 +38,9 @@ export function spawnEnemy(scene, type, x, y, isBoss = false) {
   enemy.setCollideWorldBounds(true);
 
   if (isBoss) {
-    enemy.setScale(2.2); // displayed ~70 px — imposing!
+    enemy.setScale(3); // 48 px display — imposing and crisp (integer scale keeps pixel grid sharp)
 
-    // Boss charge state machine
+    // Boss charge state machine (shared across all boss types)
     enemy._chargeState  = 'idle';
     enemy._chargeTimer  = 3000 + Math.random() * 2000; // ms until first charge
     enemy._windupDur    = 0;
@@ -48,15 +48,26 @@ export function spawnEnemy(scene, type, x, y, isBoss = false) {
     enemy._chargeVx     = 0;
     enemy._chargeVy     = 0;
 
-    // HP bar (two rectangles — background + fill, both world-space)
-    const hpBg   = scene.add.rectangle(x, y - 28, 42, 6, 0x330000, 0.9).setDepth(9.6);
-    const hpFill = scene.add.rectangle(x - 21, y - 28, 42, 6, 0xff2222, 1)
+    // Type-specific behaviour flags
+    if (type === 'lint_titan') {
+      // Lint Titan: root-and-burst — freezes briefly then lunges at double speed
+      enemy._burstSpeed    = stats.speed * 2.4;
+      enemy._rootDur       = 600; // ms frozen during wind-up
+    }
+    if (type === 'paper_wraith') {
+      // Paper Wraith: teleports to a random position near the player when HP drops below 50%
+      enemy._hasTeleported = false;
+    }
+
+    // HP bar — offset raised to match 3× scale (24px half-height + margin)
+    const hpBg   = scene.add.rectangle(x, y - 34, 52, 6, 0x330000, 0.9).setDepth(9.6);
+    const hpFill = scene.add.rectangle(x - 26, y - 34, 52, 6, 0xff2222, 1)
       .setOrigin(0, 0.5).setDepth(9.7);
     enemy._hpBarBg   = hpBg;
     enemy._hpBarFill = hpFill;
 
     // Boss name tag
-    enemy._nameTag = scene.add.text(x, y - 36, stats.name.toUpperCase(), {
+    enemy._nameTag = scene.add.text(x, y - 42, stats.name.toUpperCase(), {
       fontSize: '8px', fontFamily: 'monospace',
       color: '#ff4444', stroke: '#000', strokeThickness: 3, resolution: 2,
     }).setOrigin(0.5, 1).setDepth(9.8);
@@ -82,14 +93,14 @@ export function updateEnemy(enemy, playerSprite, delta) {
 
   // ── Boss-specific logic ──────────────────────────────────────────────────────
   if (enemy.isBoss) {
-    // Track HP bar + name tag
-    if (enemy._hpBarBg)   enemy._hpBarBg.setPosition(enemy.x, enemy.y - 28);
+    // Track HP bar + name tag (offsets match 3× scale: 24px half-height + margin)
+    if (enemy._hpBarBg)   enemy._hpBarBg.setPosition(enemy.x, enemy.y - 34);
     if (enemy._hpBarFill) {
       const ratio = Math.max(0, enemy.hp / enemy.maxHp);
-      enemy._hpBarFill.setPosition(enemy.x - 21, enemy.y - 28);
-      enemy._hpBarFill.width = 42 * ratio;
+      enemy._hpBarFill.setPosition(enemy.x - 26, enemy.y - 34);
+      enemy._hpBarFill.width = 52 * ratio;
     }
-    if (enemy._nameTag) enemy._nameTag.setPosition(enemy.x, enemy.y - 36);
+    if (enemy._nameTag) enemy._nameTag.setPosition(enemy.x, enemy.y - 42);
 
     // Charge state machine
     if (enemy._chargeState === 'charging') {
@@ -105,16 +116,37 @@ export function updateEnemy(enemy, playerSprite, delta) {
 
     if (enemy._chargeState === 'windup') {
       enemy._windupDur -= delta;
+      // Lint Titan roots in place during wind-up (already handled: velocity=0)
       enemy.body.setVelocity(0, 0);
       if (enemy._windupDur <= 0) {
         enemy._chargeState = 'charging';
         enemy._chargeDur   = 450;
         const nd = dist || 1;
-        enemy._chargeVx = (dx / nd) * enemy.baseSpeed * 3;
-        enemy._chargeVy = (dy / nd) * enemy.baseSpeed * 3;
+        // Lint Titan burst uses enhanced speed
+        const chargeSpeedMult = (enemy.enemyType === 'lint_titan') ? 4 : 3;
+        enemy._chargeVx = (dx / nd) * enemy.baseSpeed * chargeSpeedMult;
+        enemy._chargeVy = (dy / nd) * enemy.baseSpeed * chargeSpeedMult;
         enemy.clearTint();
       }
       return;
+    }
+
+    // ── Paper Wraith phase-shift (teleport at 50% HP) ─────────────────────────
+    if (enemy.enemyType === 'paper_wraith' && !enemy._hasTeleported) {
+      if (enemy.hp <= enemy.maxHp * 0.5) {
+        enemy._hasTeleported = true;
+        // Fade out → reposition near player → fade in
+        const scene = enemy.scene;
+        enemy.setAlpha(0);
+        // Pick a position 80–140px away from the player at a random angle
+        const teleportAngle = Math.random() * Math.PI * 2;
+        const teleportDist  = 80 + Math.random() * 60;
+        const tx = playerSprite.x + Math.cos(teleportAngle) * teleportDist;
+        const ty = playerSprite.y + Math.sin(teleportAngle) * teleportDist;
+        enemy.setPosition(tx, ty);
+        scene.tweens.add({ targets: enemy, alpha: 1, duration: 300 });
+        scene.sfx?.playBossWarning?.();
+      }
     }
 
     // Idle — count down to next charge when player is nearby
@@ -122,9 +154,9 @@ export function updateEnemy(enemy, playerSprite, delta) {
       enemy._chargeTimer -= delta;
       if (enemy._chargeTimer <= 0) {
         enemy._chargeState = 'windup';
-        enemy._windupDur   = 350;
+        // Lint Titan has a longer, more dramatic root wind-up
+        enemy._windupDur = (enemy.enemyType === 'lint_titan') ? 700 : 350;
         enemy.setTint(0xffff00); // yellow flash = warning
-        // Play warning sound if scene has sfx
         enemy.scene?.sfx?.playBossWarning?.();
       }
     }

--- a/frontend/src/game/entities/Player.js
+++ b/frontend/src/game/entities/Player.js
@@ -7,8 +7,9 @@ export function createPlayerAnimations(scene) {
   const anims = scene.anims;
   if (anims.exists('player_down')) return;
 
-  // Frame layout in sheet: 12 frames total (dir*3 + walkFrame)
-  // dir: 0=down, 1=left, 2=right, 3=up
+  // Frame layout:
+  //   0–11  walk (dir*3 + walkFrame): dir 0=down, 1=left, 2=right, 3=up
+  //   12–15 attack (down, left, right, up)
   const dirMap = { down: 0, left: 1, right: 2, up: 3 };
   Object.entries(dirMap).forEach(([dir, dirIdx]) => {
     const start = dirIdx * 3;
@@ -23,6 +24,17 @@ export function createPlayerAnimations(scene) {
       frames: anims.generateFrameNumbers('player', { start, end: start }),
       frameRate: 1,
       repeat: -1,
+    });
+  });
+
+  // Attack animations — single-frame held for 180ms then snap back to idle
+  const attackFrameMap = { down: 12, left: 13, right: 14, up: 15 };
+  Object.entries(attackFrameMap).forEach(([dir, frame]) => {
+    anims.create({
+      key: `player_attack_${dir}`,
+      frames: anims.generateFrameNumbers('player', { start: frame, end: frame }),
+      frameRate: 1,
+      repeat: 0,
     });
   });
 }
@@ -41,6 +53,15 @@ export function createPlayer(scene, x, y) {
   player.isAlive = true;
 
   return player;
+}
+
+// Play the directional attack frame for `durationMs`, then return to idle
+export function playAttackAnim(scene, player, durationMs = 180) {
+  const dir = player.facing ?? 'down';
+  player.play(`player_attack_${dir}`, true);
+  scene.time.delayedCall(durationMs, () => {
+    if (player.active) player.play(`player_${dir}_idle`, true);
+  });
 }
 
 export function updatePlayer(player, cursors, wasd, speed = PLAYER_SPEED) {

--- a/frontend/src/game/entities/Player.js
+++ b/frontend/src/game/entities/Player.js
@@ -58,8 +58,14 @@ export function createPlayer(scene, x, y) {
 // Play the directional attack frame for `durationMs`, then return to idle
 export function playAttackAnim(scene, player, durationMs = 180) {
   const dir = player.facing ?? 'down';
+  if (player._attackResetTimer) {
+    player._attackResetTimer.remove(false);
+    player._attackResetTimer = null;
+  }
+  player._attackLockUntil = scene.time.now + durationMs;
   player.play(`player_attack_${dir}`, true);
-  scene.time.delayedCall(durationMs, () => {
+  player._attackResetTimer = scene.time.delayedCall(durationMs, () => {
+    player._attackResetTimer = null;
     if (player.active) player.play(`player_${dir}_idle`, true);
   });
 }
@@ -88,6 +94,9 @@ export function updatePlayer(player, cursors, wasd, speed = PLAYER_SPEED) {
   }
 
   body.setVelocity(vx, vy);
+
+  const attackLocked = (player._attackLockUntil ?? 0) > player.scene.time.now;
+  if (attackLocked) return;
 
   // Direction + animation
   if (vx < 0)      { player.facing = 'left';  player.play('player_left',  true); }

--- a/frontend/src/game/sprites/SpriteGenerator.js
+++ b/frontend/src/game/sprites/SpriteGenerator.js
@@ -791,7 +791,8 @@ const BOSS_DEFS = {
         '................',
       ],
     ],
-    p: { L: NES.lpurple, l: NES.lgray, b: NES.black, R: NES.lred, '.': null },
+    // Eyes changed black→lred: glowing red eyes pop against the dark night overlay
+    p: { L: NES.lpurple, l: NES.lgray, b: NES.lred, R: NES.red, '.': null },
   },
   weed_golem: {
     frames: [
@@ -1092,18 +1093,26 @@ export function generateUISprites(scene) {
   });
   addCanvasSpriteSheet(scene, 'coin', cc, 8 * SCALE, 8 * SCALE);
 
-  // Heart sprite (8×8, 2 states: full/empty)
+  // Heart sprite (8×8 source, 2 states: full/empty)
+  // Shape: two top lobes + tapered body → proper pointed tip at bottom.
+  //   row 2: two 2px lobes (left & right)
+  //   row 3–4: full 8px width (mid body)
+  //   row 5: 6px (inset 1)
+  //   row 6: 4px (inset 2)
+  //   row 7: 2px (pointed tip)
   const hc = createCanvas(2 * 8 * SCALE, 8 * SCALE);
   const hctx = hc.getContext('2d');
   [[NES.red, NES.lred], [NES.dgray, NES.mgray]].forEach(([fg, hi], f) => {
     hctx.save();
     hctx.translate(f * 8 * SCALE, 0);
     hctx.fillStyle = fg;
-    hctx.fillRect(1 * SCALE, 2 * SCALE, 2 * SCALE, 2 * SCALE);
-    hctx.fillRect(5 * SCALE, 2 * SCALE, 2 * SCALE, 2 * SCALE);
-    hctx.fillRect(0 * SCALE, 3 * SCALE, 8 * SCALE, 3 * SCALE);
-    hctx.fillRect(1 * SCALE, 6 * SCALE, 6 * SCALE, 1 * SCALE);
-    hctx.fillRect(2 * SCALE, 7 * SCALE, 4 * SCALE, 1 * SCALE);
+    hctx.fillRect(1 * SCALE, 2 * SCALE, 2 * SCALE, 2 * SCALE); // left lobe
+    hctx.fillRect(5 * SCALE, 2 * SCALE, 2 * SCALE, 2 * SCALE); // right lobe
+    hctx.fillRect(0 * SCALE, 3 * SCALE, 8 * SCALE, 2 * SCALE); // full mid (rows 3-4)
+    hctx.fillRect(1 * SCALE, 5 * SCALE, 6 * SCALE, 1 * SCALE); // row 5 taper
+    hctx.fillRect(2 * SCALE, 6 * SCALE, 4 * SCALE, 1 * SCALE); // row 6 taper
+    hctx.fillRect(3 * SCALE, 7 * SCALE, 2 * SCALE, 1 * SCALE); // row 7 pointed tip
+    // Highlight pixel on each lobe (top-left corner)
     hctx.fillStyle = hi;
     hctx.fillRect(1 * SCALE, 2 * SCALE, 1 * SCALE, 1 * SCALE);
     hctx.fillRect(5 * SCALE, 2 * SCALE, 1 * SCALE, 1 * SCALE);
@@ -1111,7 +1120,7 @@ export function generateUISprites(scene) {
   });
   addCanvasSpriteSheet(scene, 'heart', hc, 8 * SCALE, 8 * SCALE);
 
-  // XP bar background (128×8)
+  // XP bar background (128×8) — NES-style with bracket notches at each end
   const xpW = 128, xpH = 8;
   const xpc = createCanvas(xpW, xpH);
   const xpctx = xpc.getContext('2d');
@@ -1119,14 +1128,23 @@ export function generateUISprites(scene) {
   xpctx.fillRect(0, 0, xpW, xpH);
   xpctx.fillStyle = NES.dgray;
   xpctx.fillRect(1, 1, xpW - 2, xpH - 2);
+  // Bracket notches: 2×3 yellow marks at each end
+  xpctx.fillStyle = NES.lyellow;
+  xpctx.fillRect(0, 0, 2, 3);      // top-left bracket
+  xpctx.fillRect(0, xpH - 3, 2, 3); // bottom-left bracket
+  xpctx.fillRect(xpW - 2, 0, 2, 3); // top-right bracket
+  xpctx.fillRect(xpW - 2, xpH - 3, 2, 3); // bottom-right bracket
   addCanvasTexture(scene, 'xpbar_bg', xpc);
 
+  // XP bar fill — green with 1px lyellow highlight stripe at top
   const xpfc = createCanvas(xpW, xpH);
   const xpfctx = xpfc.getContext('2d');
   xpfctx.fillStyle = NES.lgreen;
   xpfctx.fillRect(0, 0, xpW, xpH);
   xpfctx.fillStyle = NES.green;
-  xpfctx.fillRect(0, xpH - 2, xpW, 2);
+  xpfctx.fillRect(0, xpH - 2, xpW, 2);         // darker bottom stripe
+  xpfctx.fillStyle = NES.lyellow;
+  xpfctx.fillRect(0, 0, xpW, 1);               // bright top highlight
   addCanvasTexture(scene, 'xpbar_fill', xpfc);
 }
 

--- a/frontend/src/game/sprites/SpriteGenerator.js
+++ b/frontend/src/game/sprites/SpriteGenerator.js
@@ -291,7 +291,7 @@ export function generateTileset(scene) {
 // 4 directions × 3 frames each = 12 frames, 16×16 each → sheet 192×16
 
 const PLAYER_FRAMES = {
-  // down walk: frames 0,1,2
+  // down/side walk: frames 0,1,2 — hero faces the viewer
   down: [
     // frame 0 (stand)
     [
@@ -351,6 +351,66 @@ const PLAYER_FRAMES = {
       '................',
     ],
   ],
+  // up walk: frames 0,1,2 — back-of-head, no eye pixels visible
+  up: [
+    // frame 0 (stand, back)
+    [
+      '....SSSSSSSS....',
+      '...SSSSSSSSSS...',
+      '...SSSSSSSSSS...',  // no eye pixels — back of head
+      '...SSSSSSSSSS...',
+      '....HHHHHHHH....',
+      '...HHHHHHHHHH...',  // plain back of tunic
+      '..HHHHHHHHHHHH..',
+      '..HHHHHHHHHHHH..',
+      '..HHHHHHHHHHHH..',
+      '..BBBBBBBBBBBB..',
+      '..BBBBBBBBBBB...',
+      '..BBB......BBB..',
+      '...LL......LL...',
+      '...LL......LL...',
+      '..llll....llll..',
+      '................',
+    ],
+    // frame 1 (walk L, back)
+    [
+      '....SSSSSSSS....',
+      '...SSSSSSSSSS...',
+      '...SSSSSSSSSS...',
+      '...SSSSSSSSSS...',
+      '....HHHHHHHH....',
+      '...HHHHHHHHHH...',
+      '..HHHHHHHHHHHH..',
+      '..HHHHHHHHHHHH..',
+      '..HHHHHHHHHHHH..',
+      '..BBBBBBBBBBBB..',
+      '..BBBBBBBBBBB...',
+      '..BBB......BBB..',
+      '..LLL......LL...',
+      '...LL......LLL..',
+      '..llll.....lll..',
+      '................',
+    ],
+    // frame 2 (walk R, back)
+    [
+      '....SSSSSSSS....',
+      '...SSSSSSSSSS...',
+      '...SSSSSSSSSS...',
+      '...SSSSSSSSSS...',
+      '....HHHHHHHH....',
+      '...HHHHHHHHHH...',
+      '..HHHHHHHHHHHH..',
+      '..HHHHHHHHHHHH..',
+      '..HHHHHHHHHHHH..',
+      '..BBBBBBBBBBBB..',
+      '..BBBBBBBBBBB...',
+      '..BBB......BBB..',
+      '...LL......LLL..',
+      '..LLL......LL...',
+      '..lll.....llll..',
+      '................',
+    ],
+  ],
 };
 
 const PLAYER_PALETTE = {
@@ -359,7 +419,85 @@ const PLAYER_PALETTE = {
   b: NES.lyellow,                   // gold belt/buckle detail
   B: NES.lblue,                     // blue pants
   L: NES.lbrown,  l: NES.brown,    // brown boots
+  A: NES.lgray,   a: NES.white,    // broom handle (light gray shaft, white tip)
   '.': null,
+};
+
+// Attack frames — one per cardinal direction (arm extended with broom)
+// These are appended after the 12 walk frames: indices 12..15
+const PLAYER_ATTACK_FRAMES = {
+  down: [
+    '....SSSSSSSS....',
+    '...SSSSSSSSSS...',
+    '...SsSSSSSSsS...',
+    '...SSSSSSSSSS...',
+    '....HHHHHHHH....',
+    '...HhHHHHHhHH...',
+    '..HHHHHHHHHHHH..',
+    '..HHHHbbHHHHHH..',
+    '..HHHHHHHHHAHHH.',
+    '..BBBBBBBBBAHHH.',
+    '..BBBBBBBBBA....',
+    '..BBB.....Aa....',
+    '...LL.....A.....',
+    '...LL......LL...',
+    '..llll....llll..',
+    '................',
+  ],
+  up: [
+    '....SSSSSSSS....',
+    '...SSSSSSSSSS...',
+    '...SSSSSSSSSS...',
+    '...SSSSSSSSSS...',
+    '....HHHHHHHH....',
+    '...HHHHHHHHHH...',
+    '..HHHHHHHHHAAH..',
+    '..HHHHHHHHAAaH..',
+    '..HHHHHHHHAAHH..',
+    '..BBBBBBBBBBBB..',
+    '..BBBBBBBBBBB...',
+    '..BBB......BBB..',
+    '...LL......LL...',
+    '...LL......LL...',
+    '..llll....llll..',
+    '................',
+  ],
+  right: [
+    '....SSSSSSSS....',
+    '...SSSSSSSSSS...',
+    '...SsSSSSSSsS...',
+    '...SSSSSSSSSS...',
+    '....HHHHHHHH....',
+    '...HhHHHHHhHH...',
+    '..HHHHHHHHHHHH..',
+    '..HHHHbbHHAAAAa.',
+    '..HHHHHHHHHHHH..',
+    '..BBBBBBBBBBBB..',
+    '..BBBBBBBBBBB...',
+    '..BBB......BBB..',
+    '...LL......LL...',
+    '...LL......LL...',
+    '..llll....llll..',
+    '................',
+  ],
+  left: [
+    '....SSSSSSSS....',
+    '...SSSSSSSSSS...',
+    '...SsSSSSSSsS...',
+    '...SSSSSSSSSS...',
+    '....HHHHHHHH....',
+    '...HhHHHHHhHH...',
+    '..HHHHHHHHHHHH..',
+    '.aAAAAHHbbHHHHH.',
+    '..HHHHHHHHHHHH..',
+    '..BBBBBBBBBBBB..',
+    '..BBBBBBBBBBB...',
+    '..BBB......BBB..',
+    '...LL......LL...',
+    '...LL......LL...',
+    '..llll....llll..',
+    '................',
+  ],
 };
 
 // Directions: down=0, left=1, right=2, up=3 (each 3 frames)
@@ -370,32 +508,34 @@ function makePlayerFrame(frameIdx, dirOffset, palette) {
 }
 
 export function generatePlayerSheet(scene) {
-  const FRAMES = 12; // 4 dirs × 3 frames
+  const WALK_FRAMES   = 12; // 4 dirs × 3 walk frames
+  const ATTACK_FRAMES = 4;  // 1 per direction (down/left/right/up) = indices 12..15
+  const TOTAL_FRAMES  = WALK_FRAMES + ATTACK_FRAMES;
   const FS = 16;
   const SCALE = 2;
-  const W = FRAMES * FS * SCALE;
+  const W = TOTAL_FRAMES * FS * SCALE;
   const H = FS * SCALE;
 
   const c = createCanvas(W, H);
   const ctx = c.getContext('2d');
 
-  // Dir-specific palette tints for left/right (slight flip simulation)
+  // Dir-specific palettes
   const palettes = [
-    PLAYER_PALETTE, // down
-    { ...PLAYER_PALETTE }, // left — same base
-    { ...PLAYER_PALETTE }, // right
-    { ...PLAYER_PALETTE, H: NES.lbrown }, // up (show back)
+    PLAYER_PALETTE,                           // down
+    { ...PLAYER_PALETTE },                    // left
+    { ...PLAYER_PALETTE },                    // right
+    { ...PLAYER_PALETTE },                    // up (back-of-head)
   ];
 
+  // Walk frames (0–11)
   for (let dir = 0; dir < 4; dir++) {
     for (let f = 0; f < 3; f++) {
       const frameIdx = dir * 3 + f;
       const ox = frameIdx * FS * SCALE;
-      const src = PLAYER_FRAMES.down[f % 3];
+      const src = (dir === 3) ? PLAYER_FRAMES.up[f % 3] : PLAYER_FRAMES.down[f % 3];
       ctx.save();
       ctx.translate(ox, 0);
-      // Flip horizontally for left-facing
-      if (dir === 1) {
+      if (dir === 1) {           // flip for left
         ctx.translate(FS * SCALE, 0);
         ctx.scale(-1, 1);
       }
@@ -403,6 +543,21 @@ export function generatePlayerSheet(scene) {
       ctx.restore();
     }
   }
+
+  // Attack frames (12–15): down, left, right, up
+  const attackOrder = [
+    PLAYER_ATTACK_FRAMES.down,
+    PLAYER_ATTACK_FRAMES.left,
+    PLAYER_ATTACK_FRAMES.right,
+    PLAYER_ATTACK_FRAMES.up,
+  ];
+  attackOrder.forEach((grid, i) => {
+    const ox = (WALK_FRAMES + i) * FS * SCALE;
+    ctx.save();
+    ctx.translate(ox, 0);
+    drawGrid(ctx, grid, PLAYER_PALETTE, SCALE);
+    ctx.restore();
+  });
 
   addCanvasSpriteSheet(scene, 'player', c, FS * SCALE, FS * SCALE);
 }
@@ -531,7 +686,8 @@ const ENEMY_DEFS = {
         '................',
       ],
     ],
-    p: { B: NES.lbrown, b: NES.brown, w: NES.white, '.': null },
+    // Teal replaces lbrown/brown — crumb slime was previously invisible on dirt tiles
+    p: { B: NES.lteal, b: NES.teal, w: NES.white, '.': null },
   },
 };
 
@@ -676,7 +832,8 @@ const BOSS_DEFS = {
         '................',
       ],
     ],
-    p: { B: NES.green, v: NES.lgreen, V: NES.lyellow, E: NES.lyellow, r: NES.lred, '.': null },
+    // Body changed to teal — was previously grass-colored (lgreen/green), invisible on the map
+    p: { B: NES.teal, v: NES.green, V: NES.lyellow, E: NES.lyellow, r: NES.lred, '.': null },
   },
   paper_wraith: {
     frames: [
@@ -717,7 +874,8 @@ const BOSS_DEFS = {
         '................',
       ],
     ],
-    p: { P: NES.white, p: NES.lgray, R: NES.red, m: NES.mgray, '.': null },
+    // Darkened to lgray/mgray — was white/lgray, nearly invisible on light path tiles
+    p: { P: NES.lgray, p: NES.mgray, R: NES.red, m: NES.dgray, '.': null },
   },
 };
 
@@ -871,7 +1029,7 @@ export function generateBuildingSprites(scene) {
   Object.entries(BUILDING_DEFS).forEach(([key, def]) => {
     const rows = def.grid.length;
     const cols = def.grid[0].length;
-    const SCALE = 1;
+    const SCALE = 3; // 3× so buildings stand ~3 tiles tall — clearly visible in the world
     const c = createCanvas(cols * SCALE, rows * SCALE);
     const ctx = c.getContext('2d');
     drawGrid(ctx, def.grid, def.p, SCALE);
@@ -891,20 +1049,30 @@ export function generateUISprites(scene) {
   const portalColors = [NES.lyellow, NES.yellow, NES.lorange, NES.yellow];
   const portalRings  = [NES.lgreen,  NES.green,  NES.lteal,   NES.teal];
 
+  // Diamond portal shape: drawn as concentric rotated squares using NES-style pixel rows
+  // Row pixel counts (half-diamond outline): 2, 4, 6, 8, 10, 12, 10, 8, 6, 8, 10, 12, 10, 8, 6, 4
+  // This gives a 45°-rotated rhombus with a bright glow core and pulsing ring colours.
+  const portalPixels = [
+    // [outer ring x-start, width] for each row (16-row grid, centered in 16×16)
+    [7,2],[6,4],[5,6],[4,8],[3,10],[2,12],[3,10],[4,8],   // top half
+    [4,8],[3,10],[2,12],[3,10],[4,8],[5,6],[6,4],[7,2],   // bottom half
+  ];
   for (let f = 0; f < PORTAL_FRAMES; f++) {
     pctx.save();
     pctx.translate(f * FS * SCALE, 0);
-    // Outer ring
-    pctx.fillStyle = portalRings[f];
-    pctx.fillRect(4 * SCALE, 2 * SCALE, 8 * SCALE, 12 * SCALE);
-    pctx.fillRect(2 * SCALE, 4 * SCALE, 12 * SCALE, 8 * SCALE);
-    // Inner glow
-    pctx.fillStyle = portalColors[f];
-    pctx.fillRect(5 * SCALE, 3 * SCALE, 6 * SCALE, 10 * SCALE);
-    pctx.fillRect(3 * SCALE, 5 * SCALE, 10 * SCALE, 6 * SCALE);
-    // Center
+    portalPixels.forEach(([x, w], y) => {
+      // Outer ring (1px border)
+      pctx.fillStyle = portalRings[f];
+      pctx.fillRect(x * SCALE, y * SCALE, w * SCALE, SCALE);
+      // Inner glow (inset 1 pixel each side)
+      if (w > 4) {
+        pctx.fillStyle = portalColors[f];
+        pctx.fillRect((x + 1) * SCALE, y * SCALE, (w - 2) * SCALE, SCALE);
+      }
+    });
+    // Bright white core (2×2 at visual center)
     pctx.fillStyle = NES.white;
-    pctx.fillRect(6 * SCALE, 6 * SCALE, 4 * SCALE, 4 * SCALE);
+    pctx.fillRect(7 * SCALE, 7 * SCALE, 2 * SCALE, 2 * SCALE);
     pctx.restore();
   }
   addCanvasSpriteSheet(scene, 'portal', pc, FS * SCALE, FS * SCALE);

--- a/frontend/src/game/systems/BattleSystem.js
+++ b/frontend/src/game/systems/BattleSystem.js
@@ -31,15 +31,32 @@ export class BattleSystem {
     const damage = stats.damage;
     let   hit    = 0;
 
+    // Directional facing vector for arc check
+    const facingVec = {
+      down:  [  0,  1],
+      up:    [  0, -1],
+      left:  [ -1,  0],
+      right: [  1,  0],
+    }[playerSprite.facing ?? 'down'] ?? [0, 1];
+
+    // Sponge (throw) hits full circle; melee weapons use a 120° front arc.
+    // cos(60°) = 0.5 — dot product threshold for ±60° half-angle = 120° cone.
+    const isRanged = (weapon === 'sponge');
+    const ARC_DOT  = 0.5; // 0.5 = cos 60° → 120° full cone
+
     enemies.getChildren().forEach((enemy) => {
       if (!enemy.active) return;
       const dx = enemy.x - playerSprite.x;
       const dy = enemy.y - playerSprite.y;
       const dist = Math.sqrt(dx * dx + dy * dy);
-      if (dist <= range) {
-        this.hurtEnemy(enemy, damage);
-        hit++;
+      if (dist > range) return;
+      if (!isRanged) {
+        // Dot product of normalised enemy direction vs facing direction
+        const dot = (dx / (dist || 1)) * facingVec[0] + (dy / (dist || 1)) * facingVec[1];
+        if (dot < ARC_DOT) return; // outside the forward 120° cone
       }
+      this.hurtEnemy(enemy, damage);
+      hit++;
     });
 
     // ── Combo tracker ────────────────────────────────────────────────────
@@ -103,14 +120,74 @@ export class BattleSystem {
     const coinDrop = Math.round((enemy.coinDrop ?? 1) * (mult > 1 ? 1.5 : 1));
     this.scene.events.emit('enemyDefeated', { enemy, xpDrop, coinDrop });
 
-    const finalScale = enemy.isBoss ? 3 : 2;
-    this.scene.tweens.add({
-      targets: enemy,
-      alpha: 0,
-      scaleX: finalScale,
-      scaleY: finalScale,
-      duration: enemy.isBoss ? 500 : 300,
-      onComplete: () => enemy.destroy(),
+    this._playDeathAnimation(enemy);
+  }
+
+  _playDeathAnimation(enemy) {
+    const scene = this.scene;
+    const type  = enemy.enemyType;
+
+    if (enemy.isBoss) {
+      // Boss: big flash + dramatic scale-burst
+      const flash = scene.add.rectangle(
+        enemy.x, enemy.y, scene.cameras.main.width, scene.cameras.main.height,
+        0xffffff, 0,
+      ).setScrollFactor(0).setDepth(200);
+      scene.tweens.add({
+        targets: flash, alpha: 0.45,
+        yoyo: true, duration: 120, repeat: 1,
+        onComplete: () => flash.destroy(),
+      });
+      scene.tweens.add({
+        targets: enemy, alpha: 0, scaleX: 4, scaleY: 4,
+        duration: 500, ease: 'Power2',
+        onComplete: () => enemy.destroy(),
+      });
+      return;
+    }
+
+    if (type === 'dust_bunny') {
+      // Dust bunny: scatter into 6 tiny white pixel puffs
+      for (let i = 0; i < 6; i++) {
+        const angle  = (Math.PI * 2 * i) / 6;
+        const puff   = scene.add.rectangle(enemy.x, enemy.y, 4, 4, 0xbcbcbc, 1)
+          .setDepth(12);
+        scene.tweens.add({
+          targets: puff,
+          x: enemy.x + Math.cos(angle) * 28,
+          y: enemy.y + Math.sin(angle) * 28,
+          alpha: 0, scaleX: 0.3, scaleY: 0.3,
+          duration: 280, ease: 'Power1',
+          onComplete: () => puff.destroy(),
+        });
+      }
+      scene.tweens.add({
+        targets: enemy, alpha: 0, scaleX: 1.8, scaleY: 0.3,
+        duration: 180, onComplete: () => enemy.destroy(),
+      });
+      return;
+    }
+
+    if (type === 'crumb_slime') {
+      // Slime: flatten and fade like a splat
+      scene.tweens.add({
+        targets: enemy,
+        alpha: 0.7, scaleX: 2.5, scaleY: 0.4,
+        duration: 120, ease: 'Power2',
+        onComplete: () => {
+          scene.tweens.add({
+            targets: enemy, alpha: 0, duration: 200,
+            onComplete: () => enemy.destroy(),
+          });
+        },
+      });
+      return;
+    }
+
+    // Default (sock_goblin and any future enemy): scale + fade
+    scene.tweens.add({
+      targets: enemy, alpha: 0, scaleX: 2, scaleY: 2,
+      duration: 300, onComplete: () => enemy.destroy(),
     });
   }
 
@@ -123,6 +200,17 @@ export class BattleSystem {
     this.cooldowns[key] = now;
 
     this.scene.events.emit('playerHurt', { damage: 1 });
+
+    // Blink the player sprite for the full 1-second i-frame window so the
+    // player always knows when they're protected (6 blinks × 85ms yoyo ≈ 1 s).
+    this.scene.tweens.add({
+      targets: player,
+      alpha: 0.25,
+      yoyo: true,
+      repeat: 5,
+      duration: 85,
+      onComplete: () => player.setAlpha(1),
+    });
 
     // Screen shake + white flash — much more impactful than a red tint
     this.scene.cameras.main.shake(150, 0.008);

--- a/frontend/src/game/systems/BattleSystem.js
+++ b/frontend/src/game/systems/BattleSystem.js
@@ -51,9 +51,12 @@ export class BattleSystem {
       const dist = Math.sqrt(dx * dx + dy * dy);
       if (dist > range) return;
       if (!isRanged) {
-        // Dot product of normalised enemy direction vs facing direction
-        const dot = (dx / (dist || 1)) * facingVec[0] + (dy / (dist || 1)) * facingVec[1];
-        if (dot < ARC_DOT) return; // outside the forward 120° cone
+        // dist === 0 means the enemy is directly on top of the player — always in-arc.
+        // Otherwise compute dot product of normalised enemy direction vs facing direction.
+        if (dist > 0) {
+          const dot = (dx / dist) * facingVec[0] + (dy / dist) * facingVec[1];
+          if (dot < ARC_DOT) return; // outside the forward 120° cone
+        }
       }
       this.hurtEnemy(enemy, damage);
       hit++;

--- a/frontend/src/game/systems/BattleSystem.js
+++ b/frontend/src/game/systems/BattleSystem.js
@@ -70,7 +70,7 @@ export class BattleSystem {
 
     const count    = this._recentHits.length;
     const newMult  = count >= 5 ? 3 : count >= 3 ? 2 : 1;
-    if (newMult > this._lastComboMult) {
+    if (hit > 0 && newMult > 1) {
       this._lastComboMult   = newMult;
       this._comboMultiplier = newMult;
       this.scene.events.emit('comboHit', { multiplier: newMult });
@@ -129,8 +129,9 @@ export class BattleSystem {
 
     if (enemy.isBoss) {
       // Boss: big flash + dramatic scale-burst
+      const cam = scene.cameras.main;
       const flash = scene.add.rectangle(
-        enemy.x, enemy.y, scene.cameras.main.width, scene.cameras.main.height,
+        cam.width / 2, cam.height / 2, cam.width, cam.height,
         0xffffff, 0,
       ).setScrollFactor(0).setDepth(200);
       scene.tweens.add({

--- a/frontend/src/game/ui/HUD.js
+++ b/frontend/src/game/ui/HUD.js
@@ -32,9 +32,15 @@ export class HUD {
     const HUD_BG_H = xpY + 12 + 6;
 
     // ── Dark background strip for top-left HUD ───────────────────────
+    // Width covers hearts row OR xp bar + level badge, whichever is wider.
+    // BAR_W * 1.25 = 160px bar + 50px for level badge text = 210px content.
+    const HUD_BG_CONTENT = Math.max(
+      MAX_HEARTS * (HEART_SIZE + HEART_GAP),   // hearts: 135px
+      BAR_W * 1.25 + 50,                        // xp bar + level badge: 210px
+    );
     const bgLeft = scene.add.graphics();
     bgLeft.fillStyle(0x000000, 0.55);
-    bgLeft.fillRoundedRect(2, 2, HUD_BG_W + 52, HUD_BG_H, 5);
+    bgLeft.fillRoundedRect(2, 2, PADDING + HUD_BG_CONTENT + 6, HUD_BG_H, 5);
     bgLeft.setScrollFactor(0).setDepth(HUD_DEPTH - 1);
 
     // ── Hearts (top-left) ────────────────────────────────────────────
@@ -75,7 +81,7 @@ export class HUD {
       stroke: '#000000',
       strokeThickness: 4,
       resolution: 2,
-    }).setScrollFactor(0).setDepth(HUD_DEPTH);
+    }).setScrollFactor(0).setDepth(HUD_DEPTH + 3); // above xpFill crop edge
 
     // ── Coin counter (top-right) ──────────────────────────────────────
     const coinX = W - PADDING - 48;
@@ -160,6 +166,19 @@ export class HUD {
     mmBorder.lineStyle(1, 0x0028f8, 0.55);
     mmBorder.strokeRect(MM_X, MM_Y, MM_SIZE, MM_SIZE);
     mmBorder.setScrollFactor(0).setDepth(HUD_DEPTH + 1);
+
+    // Path tile layer — main cross paths run through tile 19–20 (midRow/midCol of 40×40 map).
+    // Each tile = 2px on the 80px mini-map (80 / 40 = 2).
+    // The path is 2 tiles wide, so draw a 4px-wide cross centred at tile 19.5.
+    const mmPath = scene.add.graphics();
+    mmPath.fillStyle(0xbcbcbc, 0.30); // light grey, semi-transparent
+    const pathTile  = 19;             // first of the two mid-column/row tiles
+    const pathPx    = pathTile * 2;   // pixel position on the 80px map
+    // Vertical path (columns 19–20 → x 38–41)
+    mmPath.fillRect(MM_X + pathPx, MM_Y, 4, MM_SIZE);
+    // Horizontal path (rows 19–20 → y 38–41)
+    mmPath.fillRect(MM_X, MM_Y + pathPx, MM_SIZE, 4);
+    mmPath.setScrollFactor(0).setDepth(HUD_DEPTH + 1);
 
     // Portal markers (static) — castle marker larger and brighter
     const scale = MM_SIZE / WORLD_PX;

--- a/frontend/src/game/ui/HUD.js
+++ b/frontend/src/game/ui/HUD.js
@@ -332,17 +332,25 @@ export class HUD {
 
   showCombo(multiplier) {
     if (!this._comboLabel) return;
+    this.scene.tweens.killTweensOf(this._comboLabel);
+    if (this._comboFadeTimer) {
+      this._comboFadeTimer.remove(false);
+      this._comboFadeTimer = null;
+    }
+
     const color = multiplier >= 3 ? '#ff4444' : '#ff8800';
     const stars = multiplier >= 3 ? '★★★' : '★★';
     this._comboLabel.setText(`${multiplier}× COMBO! ${stars}`)
       .setColor(color).setVisible(true).setAlpha(1);
 
     // Cancel any running fade and restart 1.5 s countdown
-    if (this._comboFadeTimer) this._comboFadeTimer.remove(false);
     this._comboFadeTimer = this.scene.time.delayedCall(1500, () => {
       this.scene.tweens.add({
         targets: this._comboLabel, alpha: 0, duration: 400,
-        onComplete: () => this._comboLabel?.setVisible(false),
+        onComplete: () => {
+          this._comboLabel?.setVisible(false);
+          this._comboFadeTimer = null;
+        },
       });
     });
   }

--- a/frontend/src/game/ui/HUD.js
+++ b/frontend/src/game/ui/HUD.js
@@ -28,7 +28,6 @@ export class HUD {
 
     const xpY  = PADDING + HEART_SIZE + 6;
     const BAR_W = 128;
-    const HUD_BG_W = PADDING + MAX_HEARTS * (HEART_SIZE + HEART_GAP) + 4;
     const HUD_BG_H = xpY + 12 + 6;
 
     // ── Dark background strip for top-left HUD ───────────────────────

--- a/frontend/src/game/ui/HUD.js
+++ b/frontend/src/game/ui/HUD.js
@@ -2,7 +2,7 @@
 // All elements are fixed to the camera (setScrollFactor(0)).
 
 import Phaser from 'phaser';
-import { xpForLevel, levelFromXp, PORTAL_ZONES, MAP_COLS, TILE_SIZE } from '../data/WorldData.js';
+import { xpForLevel, levelFromXp, PORTAL_ZONES, BOSS_ZONES, MAP_COLS, TILE_SIZE } from '../data/WorldData.js';
 
 const MAX_HEARTS   = 5;
 const HUD_DEPTH    = 100;
@@ -109,6 +109,20 @@ export class HUD {
     // ── Mini-map (top-right, below coin counter) ──────────────────────
     this._buildMinimap(W);
 
+    // ── Combo counter (below XP bar, hidden until first combo) ──────
+    this._comboLabel = scene.add.text(PADDING, xpY + 20, '', {
+      fontSize: '10px', fontFamily: 'monospace',
+      color: '#ff8800', stroke: '#000000', strokeThickness: 3, resolution: 2,
+    }).setScrollFactor(0).setDepth(HUD_DEPTH + 5).setVisible(false);
+    this._comboFadeTimer = null;
+
+    // ── Day/night clock icon (top-center) ───────────────────────────
+    // Unicode sun ☀ → moon ☾ tint shifts as the overlay darkens.
+    this._dayNightLabel = scene.add.text(W / 2, 6, '☀', {
+      fontSize: '12px', fontFamily: 'monospace', color: '#fcd860',
+      stroke: '#000000', strokeThickness: 3, resolution: 2,
+    }).setScrollFactor(0).setDepth(HUD_DEPTH).setOrigin(0.5, 0);
+
     // ── Touch action buttons (bottom) ────────────────────────────────
     if (scene.sys.game.device.input.touch) {
       this._buildTouchControls();
@@ -141,14 +155,32 @@ export class HUD {
       stroke: '#000', strokeThickness: 2, resolution: 2,
     }).setScrollFactor(0).setDepth(HUD_DEPTH).setOrigin(0.5, 1);
 
-    // Portal markers (static)
+    // Water border trace — gives the map geographic context
+    const mmBorder = scene.add.graphics();
+    mmBorder.lineStyle(1, 0x0028f8, 0.55);
+    mmBorder.strokeRect(MM_X, MM_Y, MM_SIZE, MM_SIZE);
+    mmBorder.setScrollFactor(0).setDepth(HUD_DEPTH + 1);
+
+    // Portal markers (static) — castle marker larger and brighter
     const scale = MM_SIZE / WORLD_PX;
     PORTAL_ZONES.forEach((zone) => {
       const px = MM_X + zone.x * TILE_SIZE * scale;
       const py = MM_Y + zone.y * TILE_SIZE * scale;
       const colorHex = zone.color ?? 0xffffff;
-      scene.add.rectangle(px, py, 4, 4, colorHex, 0.9)
+      const sz = zone.isRewardShop ? 6 : 4;
+      scene.add.rectangle(px, py, sz, sz, colorHex, 0.9)
         .setScrollFactor(0).setDepth(HUD_DEPTH + 1).setOrigin(0.5);
+    });
+
+    // Boss respawn timer labels — shown when boss is defeated (re-evaluated in update)
+    this._bossTimers = BOSS_ZONES.map((bz) => {
+      const px = MM_X + bz.x * TILE_SIZE * scale;
+      const py = MM_Y + bz.y * TILE_SIZE * scale;
+      const label = scene.add.text(px, py - 4, '', {
+        fontSize: '5px', fontFamily: 'monospace', color: '#ff8888',
+        stroke: '#000', strokeThickness: 2, resolution: 2,
+      }).setScrollFactor(0).setDepth(HUD_DEPTH + 3).setOrigin(0.5, 1);
+      return { bossType: bz.type, label };
     });
 
     // Dynamic graphics (player + enemies) — redrawn each frame
@@ -181,6 +213,23 @@ export class HUD {
     if (player) {
       gfx.fillStyle(0xffffff, 1);
       gfx.fillRect(mmX + player.x * scale - 2, mmY + player.y * scale - 2, 4, 4);
+    }
+
+    // Boss respawn countdown labels
+    const bossDefeats = this.scene.gameData?.bossDefeats ?? {};
+    const RESPAWN_MS  = 24 * 60 * 60 * 1000;
+    if (this._bossTimers) {
+      this._bossTimers.forEach(({ bossType, label }) => {
+        const defeatedAt = bossDefeats[bossType] ?? 0;
+        const remaining  = defeatedAt ? RESPAWN_MS - (Date.now() - defeatedAt) : 0;
+        if (remaining > 0) {
+          const hrs = Math.ceil(remaining / (60 * 60 * 1000));
+          label.setText(`${hrs}h`);
+          label.setVisible(true);
+        } else {
+          label.setVisible(false);
+        }
+      });
     }
   }
 
@@ -279,6 +328,37 @@ export class HUD {
     });
     atkBtn.on('pointerup',  () => { this.touchKeys.attack.isDown = false; });
     atkBtn.on('pointerout', () => { this.touchKeys.attack.isDown = false; });
+  }
+
+  showCombo(multiplier) {
+    if (!this._comboLabel) return;
+    const color = multiplier >= 3 ? '#ff4444' : '#ff8800';
+    const stars = multiplier >= 3 ? '★★★' : '★★';
+    this._comboLabel.setText(`${multiplier}× COMBO! ${stars}`)
+      .setColor(color).setVisible(true).setAlpha(1);
+
+    // Cancel any running fade and restart 1.5 s countdown
+    if (this._comboFadeTimer) this._comboFadeTimer.remove(false);
+    this._comboFadeTimer = this.scene.time.delayedCall(1500, () => {
+      this.scene.tweens.add({
+        targets: this._comboLabel, alpha: 0, duration: 400,
+        onComplete: () => this._comboLabel?.setVisible(false),
+      });
+    });
+  }
+
+  // Called each frame with the current night overlay alpha (0 = full day, 0.55 = full night)
+  updateNightCycle(nightAlpha) {
+    if (!this._dayNightLabel) return;
+    // Cross-fade: day (☀ yellow) → night (☾ light-blue)
+    if (nightAlpha > 0.35) {
+      this._dayNightLabel.setText('☾');
+      // Lerp color toward light-blue at peak night
+      this._dayNightLabel.setColor('#a4e4fc');
+    } else {
+      this._dayNightLabel.setText('☀');
+      this._dayNightLabel.setColor('#fcd860');
+    }
   }
 
   update(gameData) {

--- a/frontend/src/pages/AdventureMode.jsx
+++ b/frontend/src/pages/AdventureMode.jsx
@@ -65,12 +65,13 @@ export default function AdventureMode() {
 
   useEffect(() => {
     if (!containerRef.current || !user) return;
+    const mobile = window.innerWidth <= 480;
 
     const game = createGame(containerRef.current.id, {
       userId:     String(user.id),
       userName:   user.username ?? user.display_name ?? 'Hero',
       isKid:      user.role === 'kid',   // gates backend progress-sync POST in WorldScene
-      headerH:    HEADER_H,
+      headerH:    mobile ? 0 : HEADER_H, // no React header on mobile — full canvas height
       onExit:     handleExit,
       onComplete: handleGameEvent,
     });
@@ -152,6 +153,10 @@ export default function AdventureMode() {
 
   const level = gameData ? levelFromXp(gameData.xp) : null;
 
+  // On narrow mobile screens (≤480 px) collapse the header to save vertical space.
+  // The Exit button is instead rendered as a small overlay chip inside the canvas area.
+  const isMobile = typeof window !== 'undefined' && window.innerWidth <= 480;
+
   // Render via portal so position:fixed is relative to the true viewport,
   // not a Layout ancestor that has overflow-x:clip.
   return createPortal(
@@ -162,7 +167,8 @@ export default function AdventureMode() {
       alignItems: 'center',
       zIndex: 9999,
     }}>
-      {/* Header bar */}
+      {/* Header bar — hidden on narrow mobile, replaced by canvas overlay */}
+      {!isMobile && (
       <div style={{
         width: '100%',
         height: HEADER_H,
@@ -194,6 +200,7 @@ export default function AdventureMode() {
           }}
         >Exit</button>
       </div>
+      )}
 
       {/* Game canvas fills the remaining viewport */}
       <div style={{ position: 'relative', flex: 1, width: '100%', minHeight: 0 }}>
@@ -202,6 +209,19 @@ export default function AdventureMode() {
           ref={containerRef}
           style={{ position: 'absolute', inset: 0 }}
         />
+
+        {/* Mobile-only floating Exit chip — overlays the canvas top-right */}
+        {isMobile && (
+          <button
+            onClick={handleExit}
+            style={{
+              position: 'absolute', top: 6, right: 6, zIndex: 20,
+              background: 'rgba(18,18,18,0.85)', border: '1px solid #3a3a3a',
+              borderRadius: 4, color: '#888', padding: '3px 10px',
+              fontFamily: 'monospace', fontSize: 9, cursor: 'pointer',
+            }}
+          >✕ Exit</button>
+        )}
 
         {!gameReady && (
           <div style={{

--- a/frontend/src/pages/AdventureMode.jsx
+++ b/frontend/src/pages/AdventureMode.jsx
@@ -138,7 +138,7 @@ export default function AdventureMode() {
         scene.sfx?.playChoreComplete();
         if (activePortal) {
           const currentLevel = scene.gameData.portalRestoreLevels?.[activePortal.id] ?? 0;
-          const newLevel = Math.min(currentLevel + 1, 3);
+          const newLevel = Math.min(currentLevel + 1, 4);
           scene.gameData.portalRestoreLevels[activePortal.id] = newLevel;
           scene.portalMgr?.setRestoreLevel(activePortal.id, newLevel);
           scene.hud?.showFloatingText(

--- a/frontend/src/pages/AdventureMode.jsx
+++ b/frontend/src/pages/AdventureMode.jsx
@@ -137,7 +137,9 @@ export default function AdventureMode() {
         scene.gameData.coins = next.coins;
         scene.sfx?.playChoreComplete();
         if (activePortal) {
-          const currentLevel = scene.gameData.portalRestoreLevels?.[activePortal.id] ?? 0;
+          // Guard: older/partial saves may not have this field yet
+          scene.gameData.portalRestoreLevels ||= {};
+          const currentLevel = scene.gameData.portalRestoreLevels[activePortal.id] ?? 0;
           const newLevel = Math.min(currentLevel + 1, 4);
           scene.gameData.portalRestoreLevels[activePortal.id] = newLevel;
           scene.portalMgr?.setRestoreLevel(activePortal.id, newLevel);


### PR DESCRIPTION
## Summary

Complete implementation of all 4 phases from the adventure mode art & design review.

### Phase 1 — Critical visual bugs (6 fixes)
- **Building scale**: `SCALE = 1 → 3` — kitchen/laundry/castle were ~22px tall in a 1280px world; now correctly ~96px (3 tiles)
- **Crumb slime**: `lbrown/brown → lteal/teal` — was invisible on dirt tiles (same palette as the tile itself)
- **Weed golem**: body `lgreen/green → teal/green` — was invisible on grass (same palette as the most common tile)
- **Paper wraith**: `white/lgray → lgray/mgray` — was invisible on path tiles
- **Boss scale**: `2.2× → 3×` — integer scale gives crisp NES pixels; HP bar offsets updated to match
- **I-frame blink**: player flashes alpha 0.25 × 6 for 1 second after being hit — you can now see when you're invincible

### Phase 2 — Gameplay legibility (4 features)
- **Portal restore dots**: `◆◆◇◇` health indicator in QuestPortalOverlay header (reads from `gameData.portalRestoreLevels`)
- **Broom starter card**: greyed-out reference card at the top of the weapon shop so kids have a comparison baseline
- **Boss respawn countdown**: remaining hours shown as mini-map labels above boss spawn tiles when defeated
- **Day/night icon**: ☀/☾ in HUD top-center; crossfades colour at nightAlpha > 0.35

### Phase 3 — Art polish (6 improvements)
- **Player up-facing sprite**: dedicated back-of-head frames — removes the visual bug of the hero's face showing when walking upward
- **Directional attack frame**: sprite sheet expanded to 16 frames (12 walk + 4 attack); arm-extended broom frame plays for 180ms on swing
- **Portal diamond shape**: replaced axis-aligned rectangle fills with a proper 45°-rotated rhombus with bright glow core
- **Differentiated death animations**: dust bunny scatters into 6 pixel puffs; slime flattens and fades (splat); boss triggers a screen flash
- **Combo HUD counter**: persistent `2× COMBO! ★★` label below XP bar, 1.5 s fade-out on idle
- **Mini-map improvements**: water border trace, castle portal is 6×6 (larger), boss respawn labels at boss positions

### Phase 4 — Systemic enhancements (5 features)
- **Directional attack arc**: 120° forward cone replaces omnidirectional circle (sponge retains full-circle "throw" mechanic)
- **Weapon-specific VFX**: broom = diagonal yellow slash; vacuum = blue beam; soap = 5-point orange splatter; sponge = 8-point radial burst
- **Boss behaviour differentiation**: lint_titan has 700ms root wind-up + 4× speed burst; paper_wraith teleports near player at 50% HP
- **Mobile header collapse**: screens ≤480 px hide the React header bar entirely, gaining the full viewport for the canvas; a floating `✕ Exit` chip appears inside the canvas instead
- **Portal glow by restore level**: dimmer + slower pulse at level 0; brighter green + faster pulse + slightly larger scale as the zone heals

## Test plan
- [ ] Launch Adventure Mode as a kid user — confirm buildings are clearly visible (3-tile height)
- [ ] Walk onto dirt tiles — crumb slime (now teal) should be clearly visible
- [ ] Walk on grass — weed golem (now teal body) visible
- [ ] Walk on path tiles — paper wraith (now grey) visible  
- [ ] Take contact damage — player should blink for ~1 second
- [ ] Press SPACE to attack — directional swing frame plays; VFX matches weapon
- [ ] Equip each weapon — confirm different VFX (slash / beam / splatter / burst)
- [ ] Attack enemy outside 120° forward arc — should not register a hit
- [ ] Enter Reward Castle weapon shop — broom starter card appears at top
- [ ] Complete a chore in a portal — restore level dots increment (◆→◆◆)
- [ ] Defeat a boss — mini-map label shows hours remaining until respawn
- [ ] Let day/night cycle advance — ☀ becomes ☾ around the midpoint
- [ ] Test on mobile (≤480px) — React header hidden, floating Exit chip visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)