### PR TITLE
feat: add safer AI quest generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,8 @@ TZ=America/Chicago
 # Optional — expose internal /debug endpoints (dev only, default: false)
 # When false, /api/chores/{id}/debug returns 404 even to authenticated parents
 # ENABLE_DEBUG_ENDPOINTS=true
+
+# Optional — enable "Generate with AI" quest styling (uses Google Gemini's free tier).
+# Get a free key (no billing/credit card required) at https://aistudio.google.com/apikey
+# When unset, the AI button is hidden and the app works exactly as before.
+# GEMINI_API_KEY=your-gemini-api-key

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -321,6 +321,11 @@ async def get_feature_settings(
     features["grace_period_days"] = "1"
     for s in settings_list:
         features[s.key] = s.value
+    # Env-derived capability (not a DB setting): AI quest generation is only
+    # available when a Gemini API key is configured in the deployment.
+    features["ai_quest_generation"] = (
+        "true" if os.environ.get("GEMINI_API_KEY") else "false"
+    )
     return features
 
 

--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -380,7 +380,7 @@ _GEMINI_RESPONSE_SCHEMA = {
 }
 
 def _build_ai_example_block() -> str:
-    """Use static style anchors so family chore data never leaves the app."""
+    """Build example block for AI prompt styling."""
     return "\n\n".join(
         f"Title: {title}\nDescription: {desc}"
         for title, desc in _SEED_STYLE_EXAMPLES
@@ -393,7 +393,7 @@ async def generate_quest(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(require_parent),
 ):
-    """Rewrite a plain chore idea as an on-style RPG quest draft.
+    """Rewrite a plain chore idea as an on-theme RPG quest draft.
 
     Returns a suggested title/description/points/difficulty/category. Nothing is
     saved — the parent reviews and edits in the create form, then saves via the
@@ -416,8 +416,6 @@ async def generate_quest(
     categories = cat_result.scalars().all()
     category_names = [c.name for c in categories]
 
-    # Static examples preserve the fantasy tone without sending family-specific
-    # chore titles or descriptions to a third-party model.
     example_block = _build_ai_example_block()
     category_block = ", ".join(category_names) if category_names else "General"
 

--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import datetime, date, timezone, timedelta
 
 from backend.utils import utc_iso
+from backend.rate_limit import rate_limiter
 
 from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, File
 from sqlalchemy import select, and_, func, delete, text
@@ -19,6 +20,7 @@ from backend.models import (
     ChoreCategory,
     ChoreExclusion,
     ChoreRotation,
+    Difficulty,
     QuestTemplate,
     User,
     UserRole,
@@ -41,6 +43,8 @@ from backend.schemas import (
     ChoreAssignRequest,
     AssignmentRuleUpdate,
     QuestTemplateResponse,
+    QuestGenerateRequest,
+    QuestGenerateResponse,
     RotationResponse,
     RotationSummary,
     QuestFeedbackRequest,
@@ -329,6 +333,182 @@ async def list_templates(
 ):
     result = await db.execute(select(QuestTemplate))
     return [QuestTemplateResponse.model_validate(t) for t in result.scalars().all()]
+
+
+# ---------------------------------------------------------------------------
+# AI quest generation (Google Gemini free tier)
+# ---------------------------------------------------------------------------
+
+# Free-tier flash model — fast and no billing required.
+_GEMINI_MODEL = "gemini-2.0-flash"
+_AI_QUEST_RATE_LIMIT_MAX_REQUESTS = 5
+_AI_QUEST_RATE_LIMIT_WINDOW_SECONDS = 300
+_AI_QUEST_MAX_POINTS = 50
+
+# Fallback style anchors used only when the family has no chores yet.
+_SEED_STYLE_EXAMPLES = [
+    (
+        "The Chamber of Rest",
+        "Venture into your sleeping quarters and restore order to the land. "
+        "Make the bed, clear the floor, and banish the chaos that lurks within.",
+    ),
+    (
+        "Dishwasher's Oath",
+        "The enchanted basin overflows with relics of past feasts. Empty its "
+        "contents and return each vessel to its rightful place in the kingdom's cupboards.",
+    ),
+    (
+        "Beast Keeper's Round",
+        "The loyal creatures of the realm hunger for sustenance and care. Fill "
+        "their bowls, refresh their water, and tend to their domain.",
+    ),
+]
+
+_GEMINI_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "description": {"type": "string"},
+        "points": {"type": "integer"},
+        "difficulty": {
+            "type": "string",
+            "enum": [d.value for d in Difficulty],
+        },
+        "category_name": {"type": "string"},
+    },
+    "required": ["title", "description", "points", "difficulty", "category_name"],
+}
+
+
+def gemini_enabled() -> bool:
+    """True when a Gemini API key is configured in the environment."""
+    return bool(os.environ.get("GEMINI_API_KEY"))
+
+
+def _build_ai_example_block() -> str:
+    """Use static style anchors so family chore data never leaves the app."""
+    return "\n\n".join(
+        f"Title: {title}\nDescription: {desc}"
+        for title, desc in _SEED_STYLE_EXAMPLES
+    )
+
+
+@router.post("/generate", response_model=QuestGenerateResponse)
+async def generate_quest(
+    body: QuestGenerateRequest,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_parent),
+):
+    """Rewrite a plain chore idea as an on-style RPG quest draft.
+
+    Returns a suggested title/description/points/difficulty/category. Nothing is
+    saved — the parent reviews and edits in the create form, then saves via the
+    normal POST /api/chores path.
+    """
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        raise HTTPException(
+            status_code=503, detail="AI quest generation is not configured."
+        )
+
+    rate_limiter.check(
+        key=f"ai-quest-generate:{user.id}",
+        max_requests=_AI_QUEST_RATE_LIMIT_MAX_REQUESTS,
+        window_seconds=_AI_QUEST_RATE_LIMIT_WINDOW_SECONDS,
+    )
+
+    # Category names the model must choose from.
+    cat_result = await db.execute(select(ChoreCategory))
+    categories = cat_result.scalars().all()
+    category_names = [c.name for c in categories]
+
+    # Static examples preserve the fantasy tone without sending family-specific
+    # chore titles or descriptions to a third-party model.
+    example_block = _build_ai_example_block()
+    category_block = ", ".join(category_names) if category_names else "General"
+
+    system_instruction = (
+        "You are a quest writer for a family chore app that frames chores as "
+        "epic RPG/fantasy quests. Rewrite the parent's plain chore idea as a "
+        "single quest that matches the voice, tone, and style of the examples: "
+        "a short evocative fantasy title and a 1-2 sentence description that "
+        "renames ordinary household items and actions in medieval/fantasy terms "
+        "while keeping the real task clear. Pick the single best-fit category "
+        f"from this list (use the exact name): {category_block}. Suggest an XP "
+        "reward as a positive integer (easy chores ~10-15, medium ~20-25, hard "
+        "~30) and a difficulty of easy, medium, hard, or expert. Respond with "
+        "JSON only."
+    )
+    contents = (
+        f"Examples of the desired style:\n\n{example_block}\n\n"
+        f"Parent's chore idea: {body.prompt}"
+    )
+
+    try:
+        from google import genai
+        from google.genai import types
+
+        client = genai.Client(api_key=api_key)
+        response = await client.aio.models.generate_content(
+            model=_GEMINI_MODEL,
+            contents=contents,
+            config=types.GenerateContentConfig(
+                system_instruction=system_instruction,
+                response_mime_type="application/json",
+                response_schema=_GEMINI_RESPONSE_SCHEMA,
+                temperature=0.9,
+                max_output_tokens=600,
+            ),
+        )
+        import json
+
+        data = json.loads(response.text)
+    except Exception:
+        logger.exception("Gemini quest generation failed")
+        raise HTTPException(
+            status_code=502,
+            detail="The oracle could not be reached. Please try again.",
+        )
+
+    # Coerce / validate model output.
+    title = str(data.get("title") or "").strip()[:200]
+    description = str(data.get("description") or "").strip() or None
+    if not title:
+        raise HTTPException(
+            status_code=502, detail="The oracle returned an empty quest."
+        )
+
+    try:
+        points = int(data.get("points") or 10)
+    except (TypeError, ValueError):
+        points = 10
+    points = min(_AI_QUEST_MAX_POINTS, max(1, points))
+
+    raw_difficulty = str(data.get("difficulty") or "").lower()
+    try:
+        difficulty = Difficulty(raw_difficulty)
+    except ValueError:
+        difficulty = Difficulty.easy
+
+    # Resolve category name -> id (case-insensitive), mirroring the frontend.
+    category_name = str(data.get("category_name") or "").strip()
+    category_id = next(
+        (c.id for c in categories if c.name.lower() == category_name.lower()),
+        None,
+    )
+    if category_id is None and categories:
+        # Fall back to the first category so the form is still usable.
+        category_id = categories[0].id
+        category_name = categories[0].name
+
+    return QuestGenerateResponse(
+        title=title,
+        description=description,
+        points=points,
+        difficulty=difficulty,
+        category_name=category_name,
+        category_id=category_id,
+    )
 
 
 @router.get("/{chore_id}", response_model=ChoreResponse)

--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -345,7 +345,7 @@ _AI_QUEST_RATE_LIMIT_MAX_REQUESTS = 5
 _AI_QUEST_RATE_LIMIT_WINDOW_SECONDS = 300
 _AI_QUEST_MAX_POINTS = 50
 
-# Fallback style anchors used only when the family has no chores yet.
+# Static style anchors used for tone guidance in every AI generation request.
 _SEED_STYLE_EXAMPLES = [
     (
         "The Chamber of Rest",
@@ -378,12 +378,6 @@ _GEMINI_RESPONSE_SCHEMA = {
     },
     "required": ["title", "description", "points", "difficulty", "category_name"],
 }
-
-
-def gemini_enabled() -> bool:
-    """True when a Gemini API key is configured in the environment."""
-    return bool(os.environ.get("GEMINI_API_KEY"))
-
 
 def _build_ai_example_block() -> str:
     """Use static style anchors so family chore data never leaves the app."""

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -437,8 +437,8 @@ class QuestTemplateResponse(BaseModel):
 
 # AI quest generation
 class QuestGenerateRequest(BaseModel):
-    # Plain-language chore idea, e.g. "clean the garage". Length-capped as the
-    # abuse guard (there is no rate-limit library in this repo).
+    # Plain-language chore idea, e.g. "clean the garage". Length-capped as an
+    # abuse guard, with per-parent endpoint rate limiting enforced server-side.
     prompt: str = Field(min_length=3, max_length=300)
 
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -435,6 +435,22 @@ class QuestTemplateResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+# AI quest generation
+class QuestGenerateRequest(BaseModel):
+    # Plain-language chore idea, e.g. "clean the garage". Length-capped as the
+    # abuse guard (there is no rate-limit library in this repo).
+    prompt: str = Field(min_length=3, max_length=300)
+
+
+class QuestGenerateResponse(BaseModel):
+    title: str
+    description: str | None
+    points: int
+    difficulty: Difficulty
+    category_name: str
+    category_id: int | None
+
+
 # Rotations
 class RotationCreate(BaseModel):
     chore_id: int

--- a/frontend/src/components/QuestCreateModal.jsx
+++ b/frontend/src/components/QuestCreateModal.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { api } from '../api/client';
 import { useTheme } from '../hooks/useTheme';
+import { useSettings } from '../hooks/useSettings';
 import { themedTitle, themedDescription } from '../utils/questThemeText';
 import Modal from './Modal';
 import {
@@ -8,6 +9,7 @@ import {
   Star,
   Scroll,
   CheckCircle2,
+  Sparkles,
 } from 'lucide-react';
 
 const DIFFICULTY_OPTIONS = [
@@ -38,12 +40,17 @@ export default function QuestCreateModal({
   editingChore,
 }) {
   const { colorTheme } = useTheme();
+  const { ai_quest_generation: aiEnabled } = useSettings();
   const [form, setForm] = useState({ ...emptyForm });
   const [formError, setFormError] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [templates, setTemplates] = useState([]);
   const [showTemplates, setShowTemplates] = useState(false);
   const [existingTitles, setExistingTitles] = useState(new Set());
+  const [showAi, setShowAi] = useState(false);
+  const [aiPrompt, setAiPrompt] = useState('');
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiError, setAiError] = useState('');
 
   useEffect(() => {
     if (isOpen) {
@@ -61,6 +68,9 @@ export default function QuestCreateModal({
       }
       setFormError('');
       setShowTemplates(false);
+      setShowAi(false);
+      setAiPrompt('');
+      setAiError('');
     }
   }, [isOpen, editingChore]);
 
@@ -97,6 +107,34 @@ export default function QuestCreateModal({
       category_id: catMatch ? String(catMatch.id) : '',
     });
     setShowTemplates(false);
+  };
+
+  const handleGenerate = async () => {
+    const prompt = aiPrompt.trim();
+    if (prompt.length < 3) {
+      setAiError('Describe the chore in a few words first.');
+      return;
+    }
+    setAiLoading(true);
+    setAiError('');
+    try {
+      const draft = await api('/api/chores/generate', {
+        method: 'POST',
+        body: { prompt },
+      });
+      setForm((prev) => ({
+        ...prev,
+        title: draft.title,
+        description: draft.description || '',
+        points: draft.points,
+        difficulty: draft.difficulty,
+        category_id: draft.category_id ? String(draft.category_id) : prev.category_id,
+      }));
+    } catch (err) {
+      setAiError(err.message || 'The oracle could not be reached. Please try again.');
+    } finally {
+      setAiLoading(false);
+    }
   };
 
   const handleSubmit = async () => {
@@ -171,6 +209,52 @@ export default function QuestCreateModal({
         {formError && (
           <div className="p-2 rounded border border-crimson/40 bg-crimson/10 text-crimson text-sm">
             {formError}
+          </div>
+        )}
+
+        {/* AI generate panel (only when creating + a Gemini key is configured) */}
+        {!editingChore && aiEnabled && (
+          <div>
+            <button
+              type="button"
+              onClick={() => setShowAi(!showAi)}
+              className="flex items-center gap-2 text-accent text-sm hover:text-accent/80 transition-colors"
+            >
+              <Sparkles size={14} />
+              {showAi ? 'Hide AI helper' : 'Generate with AI'}
+            </button>
+
+            {showAi && (
+              <div className="mt-3 space-y-2 border border-border rounded-lg p-3 bg-surface-raised/30">
+                <p className="text-muted text-xs">
+                  Describe a chore in plain words and avoid names or private details.
+                  Uses Google Gemini to style it as a quest.
+                </p>
+                <p className="text-muted text-xs">
+                  Up to 5 generations every 5 minutes. Suggested XP is capped for balance.
+                </p>
+                <textarea
+                  value={aiPrompt}
+                  onChange={(e) => setAiPrompt(e.target.value)}
+                  placeholder="e.g. clean the garage"
+                  rows={2}
+                  maxLength={300}
+                  className="field-input resize-none"
+                />
+                {aiError && (
+                  <p className="text-crimson text-xs">{aiError}</p>
+                )}
+                <button
+                  type="button"
+                  onClick={handleGenerate}
+                  disabled={aiLoading}
+                  className="game-btn game-btn-gold flex items-center gap-2"
+                >
+                  <Sparkles size={14} />
+                  {aiLoading ? 'Consulting the oracle...' : 'Generate Quest'}
+                </button>
+              </div>
+            )}
           </div>
         )}
 

--- a/frontend/src/hooks/useSettings.jsx
+++ b/frontend/src/hooks/useSettings.jsx
@@ -8,6 +8,7 @@ const SettingsContext = createContext({
   chore_trading_enabled: true,
   grace_period_days: 1,
   enable_debug_endpoints: false,
+  ai_quest_generation: false,
 });
 
 export function SettingsProvider({ children }) {
@@ -18,6 +19,7 @@ export function SettingsProvider({ children }) {
     chore_trading_enabled: true,
     grace_period_days: 1,
     enable_debug_endpoints: false,
+    ai_quest_generation: false,
   });
 
   const fetchFeatures = useCallback(async () => {
@@ -30,6 +32,7 @@ export function SettingsProvider({ children }) {
         chore_trading_enabled: data.chore_trading_enabled !== 'false',
         grace_period_days: parseInt(data.grace_period_days ?? '1', 10),
         enable_debug_endpoints: data.enable_debug_endpoints === 'true',
+        ai_quest_generation: data.ai_quest_generation === 'true',
       });
     } catch {
       // If fetch fails, keep defaults (all enabled)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ bcrypt==4.2.1
 python-multipart==0.0.27
 pywebpush==2.3.0
 cryptography==47.0.0
+google-genai==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.115.6
 uvicorn[standard]==0.34.0
 sqlalchemy[asyncio]==2.0.36
 aiosqlite==0.20.0
-pydantic==2.10.4
+pydantic==2.12.5
 pydantic-settings==2.7.1
 bcrypt==4.2.1
 python-multipart==0.0.27

--- a/tests/unit/test_ai_quest_generation.py
+++ b/tests/unit/test_ai_quest_generation.py
@@ -1,0 +1,153 @@
+import json
+import sys
+import types
+
+import pytest
+from fastapi import HTTPException
+
+from backend.models import Difficulty, UserRole
+from backend.rate_limit import rate_limiter
+from backend.routers.chores import generate_quest
+from backend.schemas import QuestGenerateRequest
+from tests.unit.conftest import make_category, make_chore, make_user
+
+
+def _install_fake_google(monkeypatch, response_payload, captured):
+    class FakeGenerateContentConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeModels:
+        async def generate_content(self, *, model, contents, config):
+            captured["model"] = model
+            captured["contents"] = contents
+            captured["config"] = config
+            return types.SimpleNamespace(text=json.dumps(response_payload))
+
+    class FakeClient:
+        def __init__(self, api_key):
+            captured["api_key"] = api_key
+            self.aio = types.SimpleNamespace(models=FakeModels())
+
+    google_module = types.ModuleType("google")
+    genai_module = types.ModuleType("google.genai")
+    genai_module.Client = FakeClient
+    genai_module.types = types.SimpleNamespace(
+        GenerateContentConfig=FakeGenerateContentConfig
+    )
+    google_module.genai = genai_module
+
+    monkeypatch.setitem(sys.modules, "google", google_module)
+    monkeypatch.setitem(sys.modules, "google.genai", genai_module)
+
+
+@pytest.mark.asyncio
+async def test_generate_quest_does_not_send_existing_family_chores(db, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+    rate_limiter._windows.clear()
+
+    parent = await make_user(db, "parent_ai", role=UserRole.parent)
+    category = await make_category(db, "Kitchen")
+    private_title = "Clean Ava's inhaler station"
+    private_description = "Wipe the medicine tray beside Ava's bed."
+    chore = await make_chore(
+        db,
+        creator_id=parent.id,
+        category_id=category.id,
+        title=private_title,
+    )
+    chore.description = private_description
+    await db.flush()
+
+    captured = {}
+    _install_fake_google(
+        monkeypatch,
+        {
+            "title": "Cupboard Crusade",
+            "description": "Restore order to the snack shelf.",
+            "points": 20,
+            "difficulty": "medium",
+            "category_name": "Kitchen",
+        },
+        captured,
+    )
+
+    response = await generate_quest(
+        QuestGenerateRequest(prompt="organize the snack shelf"),
+        db=db,
+        user=parent,
+    )
+
+    assert response.title == "Cupboard Crusade"
+    assert private_title not in captured["contents"]
+    assert private_description not in captured["contents"]
+    assert "The Chamber of Rest" in captured["contents"]
+
+
+@pytest.mark.asyncio
+async def test_generate_quest_caps_ai_points_to_safe_max(db, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+    rate_limiter._windows.clear()
+
+    parent = await make_user(db, "parent_cap", role=UserRole.parent)
+    await make_category(db, "General")
+
+    captured = {}
+    _install_fake_google(
+        monkeypatch,
+        {
+            "title": "Dragon Hoard Sort",
+            "description": "Sort the toy bin.",
+            "points": 9999,
+            "difficulty": "expert",
+            "category_name": "General",
+        },
+        captured,
+    )
+
+    response = await generate_quest(
+        QuestGenerateRequest(prompt="sort the toy bin"),
+        db=db,
+        user=parent,
+    )
+
+    assert response.points == 50
+    assert response.difficulty == Difficulty.expert
+
+
+@pytest.mark.asyncio
+async def test_generate_quest_rate_limits_per_parent(db, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+    rate_limiter._windows.clear()
+
+    parent = await make_user(db, "parent_limit", role=UserRole.parent)
+    await make_category(db, "General")
+
+    captured = {}
+    _install_fake_google(
+        monkeypatch,
+        {
+            "title": "Lantern Patrol",
+            "description": "Put away the hallway clutter.",
+            "points": 10,
+            "difficulty": "easy",
+            "category_name": "General",
+        },
+        captured,
+    )
+
+    for _ in range(5):
+        await generate_quest(
+            QuestGenerateRequest(prompt="put away hallway clutter"),
+            db=db,
+            user=parent,
+        )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await generate_quest(
+            QuestGenerateRequest(prompt="put away hallway clutter"),
+            db=db,
+            user=parent,
+        )
+
+    assert exc_info.value.status_code == 429


### PR DESCRIPTION
## Summary
- add parent-only AI quest generation in the quest creation modal when  is configured
- add a backend  endpoint backed by Gemini with category-aware quest drafting
- harden the feature by using static style examples, rate limiting requests, and capping AI-suggested XP
- expose the feature availability through admin settings and add focused unit coverage

## Testing
- pytest tests/unit/test_ai_quest_generation.py
- python3 -m compileall backend
- npm run build
