### PR TITLE
feat: AI-assisted quest generation (configurable providers)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,10 @@ TZ=America/Chicago
 # When false, /api/chores/{id}/debug returns 404 even to authenticated parents
 # ENABLE_DEBUG_ENDPOINTS=true
 
-# Optional — enable "Generate with AI" quest styling (uses Google Gemini's free tier).
-# Get a free key (no billing/credit card required) at https://aistudio.google.com/apikey
-# When unset, the AI button is hidden and the app works exactly as before.
+# Optional — AI provider env overrides for quest generation.
+# If you also configure providers in the app UI, env vars take precedence on the server.
+# Gemini stays the default provider when nothing else is selected.
 # GEMINI_API_KEY=your-gemini-api-key
+# OPENAI_API_KEY=your-openai-api-key
+# ANTHROPIC_API_KEY=your-anthropic-api-key
+# OLLAMA_BASE_URL=http://localhost:11434

--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,8 @@ TZ=America/Chicago
 # Optional — expose internal /debug endpoints (dev only, default: false)
 # When false, /api/chores/{id}/debug returns 404 even to authenticated parents
 # ENABLE_DEBUG_ENDPOINTS=true
+
+# Optional — enable "Generate with AI" quest styling (uses Google Gemini's free tier).
+# Get a free key (no billing/credit card required) at https://aistudio.google.com/apikey
+# When unset, the AI button is hidden and the app works exactly as before.
+# GEMINI_API_KEY=your-gemini-api-key

--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ A gamified family chore management app with full RPG theming. Parents create que
 
 ---
 
+## 🆕 What's New
+
+Recent additions around AI-assisted chore creation:
+
+- **AI quest drafting** in the quest create modal for parents
+- **Configurable AI providers**: Google Gemini, OpenAI, Anthropic Claude, and Ollama
+- **Provider settings in-app** under **Settings → AI Quest Generation**
+- **Privacy guardrails**: static style examples only, so existing family chore text is not sent upstream
+- **Safety limits**: 5 generations every 5 minutes per parent, plus capped AI-suggested XP
+
+For setup and day-to-day usage, see [AI-Assisted Quest Creation](#-ai-assisted-quest-creation) below or the wiki page: [AI-Assisted Quest Creation](https://github.com/turbogizzmo/ChoreQuest/wiki/AI-Assisted-Quest-Creation).
+
+---
+
 ## 🚀 Quick Start
 
 ### Requirements
@@ -110,6 +124,10 @@ When triggered, `watchdog.sh` runs `deploy.sh` which does `git pull` + `docker c
 | `VAPID_PUBLIC_KEY` | *(empty)* | VAPID public key for push notifications |
 | `VAPID_PRIVATE_KEY` | *(empty)* | VAPID private key for push notifications |
 | `VAPID_CLAIM_EMAIL` | `mailto:admin@example.com` | Contact email for push requests |
+| `GEMINI_API_KEY` | *(empty)* | Optional Gemini API key override for AI quest generation |
+| `OPENAI_API_KEY` | *(empty)* | Optional OpenAI API key override for AI quest generation |
+| `ANTHROPIC_API_KEY` | *(empty)* | Optional Anthropic API key override for AI quest generation |
+| `OLLAMA_BASE_URL` | `http://localhost:11434` | Optional Ollama base URL override for AI quest generation |
 
 ### Data persistence
 
@@ -118,6 +136,92 @@ All data lives in `./data`:
 - `uploads/` — photo proof files
 
 Back up this directory to preserve everything.
+
+---
+
+## 🤖 AI-Assisted Quest Creation
+
+Parents can turn a plain chore idea like `clean the garage` into a fantasy-styled quest draft directly from the quest creation modal.
+
+### What it does
+
+- Rewrites a plain chore into a quest-style **title** and **description**
+- Suggests **XP**, **difficulty**, and the best-fit **category**
+- Prefills the normal quest form so the parent can review and edit before saving
+
+### How to set it up
+
+You have two ways to configure AI providers:
+
+1. **In the app**
+   - Sign in as a **parent or admin**
+   - Open **Profile → Family Settings**
+   - Find **AI Quest Generation**
+   - Choose a provider, enter the required fields, and click **Save AI Provider**
+
+2. **With environment variables**
+   - Add one or more provider values to `.env`
+   - Restart the app after changing env values
+   - Environment variables take precedence over values saved in the app UI
+
+### Provider options
+
+- **Google Gemini**
+  - Required: `API key`
+  - Default provider for new setups
+  - Good first choice if you want a low-friction hosted option
+
+- **OpenAI**
+  - Required: `API key`
+  - Optional: `Organization`, `Project`
+  - Lets you choose your own GPT model
+
+- **Anthropic Claude**
+  - Required: `API key`
+  - Lets you choose your own Claude model
+
+- **Ollama**
+  - Required: `Base URL`, `Model`
+  - No API key is required by default for a local Ollama instance
+  - Useful for self-hosted/local model setups
+
+### Environment examples
+
+```env
+# Gemini
+GEMINI_API_KEY=your-gemini-api-key
+
+# OpenAI
+OPENAI_API_KEY=your-openai-api-key
+
+# Anthropic
+ANTHROPIC_API_KEY=your-anthropic-api-key
+
+# Ollama
+OLLAMA_BASE_URL=http://localhost:11434
+```
+
+### How parents use it
+
+1. Open **New Quest Scroll**
+2. Click **Generate with AI**
+3. Describe the chore in plain language
+4. Review the generated draft
+5. Edit anything you want, then save it like a normal quest
+
+### Privacy and safety behavior
+
+- Do **not** include names or private family details in the prompt
+- The app uses static style examples and does **not** send your saved family chore text as prompt context
+- Generation is limited to **5 requests every 5 minutes per parent**
+- AI-suggested XP is capped before it reaches the save flow
+- Saved provider secrets are handled separately from normal settings and are not returned to the browser in plain text
+
+### If the button does not appear
+
+- Make sure at least one provider is configured successfully
+- Check **Settings → AI Quest Generation** for the provider status pills
+- If you are using env vars, restart the app after editing `.env`
 
 ---
 
@@ -228,6 +332,7 @@ Detailed documentation lives in the [GitHub Wiki](https://github.com/turbogizzmo
 - [Streaks & Vacation](https://github.com/turbogizzmo/ChoreQuest/wiki/Streaks-and-Vacation) — streak logic, freeze, vacation mode
 - [Rotation System](https://github.com/turbogizzmo/ChoreQuest/wiki/Rotation-System) — cadences, inverse linking
 - [Parent Tools](https://github.com/turbogizzmo/ChoreQuest/wiki/Parent-Tools) — calendar, verify override, bounty board, audit log
+- [AI-Assisted Quest Creation](https://github.com/turbogizzmo/ChoreQuest/wiki/AI-Assisted-Quest-Creation) — provider setup, usage, privacy, troubleshooting
 - [Achievements & Ranks](https://github.com/turbogizzmo/ChoreQuest/wiki/Achievements-and-Ranks) — tiers, XP thresholds
 - [Avatar & Pets](https://github.com/turbogizzmo/ChoreQuest/wiki/Avatar-and-Pets) — editor, pet levels, drops
 - [Adventure Mode](https://github.com/turbogizzmo/ChoreQuest/wiki/Adventure-Mode) — gameplay loop, enemies, rewards, weapons

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -321,6 +321,11 @@ async def get_feature_settings(
     features["grace_period_days"] = "1"
     for s in settings_list:
         features[s.key] = s.value
+    # Env-derived capability (not a DB setting): AI quest generation is only
+    # available when a Gemini API key is configured in the deployment.
+    features["ai_quest_generation"] = (
+        "true" if os.environ.get("GEMINI_API_KEY") else "false"
+    )
     return features
 
 

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -22,9 +22,12 @@ from backend.schemas import (
     InviteCodeResponse,
     AuditLogResponse,
     SettingsUpdate,
+    AISettingsUpdate,
 )
 from backend.auth import hash_password
 from backend.dependencies import require_admin, require_parent, get_current_user
+from backend.services.ai_provider import get_ai_settings_payload, save_ai_settings, ai_generation_available
+from backend.services.secure_settings import SENSITIVE_SETTING_KEYS
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
@@ -292,7 +295,7 @@ async def get_settings(
     """Get all application settings as a key-value dict."""
     result = await db.execute(select(AppSetting))
     settings_list = result.scalars().all()
-    return {s.key: s.value for s in settings_list}
+    return {s.key: s.value for s in settings_list if s.key not in SENSITIVE_SETTING_KEYS}
 
 
 # ---------- GET /settings/features ----------
@@ -324,9 +327,26 @@ async def get_feature_settings(
     # Env-derived capability (not a DB setting): AI quest generation is only
     # available when a Gemini API key is configured in the deployment.
     features["ai_quest_generation"] = (
-        "true" if os.environ.get("GEMINI_API_KEY") else "false"
+        "true" if await ai_generation_available(db) else "false"
     )
     return features
+
+
+@router.get("/settings/ai")
+async def get_ai_settings(
+    db: AsyncSession = Depends(get_db),
+    _parent: User = Depends(require_parent),
+):
+    return await get_ai_settings_payload(db)
+
+
+@router.put("/settings/ai")
+async def update_ai_settings(
+    body: AISettingsUpdate,
+    db: AsyncSession = Depends(get_db),
+    _parent: User = Depends(require_parent),
+):
+    return await save_ai_settings(db, body)
 
 
 # ---------- PUT /settings ----------

--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -4,6 +4,7 @@ import uuid
 from datetime import datetime, date, timezone, timedelta
 
 from backend.utils import utc_iso
+from backend.rate_limit import rate_limiter
 
 from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, File
 from sqlalchemy import select, and_, func, delete, text
@@ -19,6 +20,7 @@ from backend.models import (
     ChoreCategory,
     ChoreExclusion,
     ChoreRotation,
+    Difficulty,
     QuestTemplate,
     User,
     UserRole,
@@ -41,6 +43,8 @@ from backend.schemas import (
     ChoreAssignRequest,
     AssignmentRuleUpdate,
     QuestTemplateResponse,
+    QuestGenerateRequest,
+    QuestGenerateResponse,
     RotationResponse,
     RotationSummary,
     QuestFeedbackRequest,
@@ -329,6 +333,182 @@ async def list_templates(
 ):
     result = await db.execute(select(QuestTemplate))
     return [QuestTemplateResponse.model_validate(t) for t in result.scalars().all()]
+
+
+# ---------------------------------------------------------------------------
+# AI quest generation (Google Gemini free tier)
+# ---------------------------------------------------------------------------
+
+# Free-tier flash model — fast and no billing required.
+_GEMINI_MODEL = "gemini-2.0-flash"
+_AI_QUEST_RATE_LIMIT_MAX_REQUESTS = 5
+_AI_QUEST_RATE_LIMIT_WINDOW_SECONDS = 300
+_AI_QUEST_MAX_POINTS = 50
+
+# Fallback style anchors used only when the family has no chores yet.
+_SEED_STYLE_EXAMPLES = [
+    (
+        "The Chamber of Rest",
+        "Venture into your sleeping quarters and restore order to the land. "
+        "Make the bed, clear the floor, and banish the chaos that lurks within.",
+    ),
+    (
+        "Dishwasher's Oath",
+        "The enchanted basin overflows with relics of past feasts. Empty its "
+        "contents and return each vessel to its rightful place in the kingdom's cupboards.",
+    ),
+    (
+        "Beast Keeper's Round",
+        "The loyal creatures of the realm hunger for sustenance and care. Fill "
+        "their bowls, refresh their water, and tend to their domain.",
+    ),
+]
+
+_GEMINI_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "description": {"type": "string"},
+        "points": {"type": "integer"},
+        "difficulty": {
+            "type": "string",
+            "enum": [d.value for d in Difficulty],
+        },
+        "category_name": {"type": "string"},
+    },
+    "required": ["title", "description", "points", "difficulty", "category_name"],
+}
+
+
+def gemini_enabled() -> bool:
+    """True when a Gemini API key is configured in the environment."""
+    return bool(os.environ.get("GEMINI_API_KEY"))
+
+
+def _build_ai_example_block() -> str:
+    """Use static style anchors so family chore data never leaves the app."""
+    return "\n\n".join(
+        f"Title: {title}\nDescription: {desc}"
+        for title, desc in _SEED_STYLE_EXAMPLES
+    )
+
+
+@router.post("/generate", response_model=QuestGenerateResponse)
+async def generate_quest(
+    body: QuestGenerateRequest,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_parent),
+):
+    """Rewrite a plain chore idea as an on-style RPG quest draft.
+
+    Returns a suggested title/description/points/difficulty/category. Nothing is
+    saved — the parent reviews and edits in the create form, then saves via the
+    normal POST /api/chores path.
+    """
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        raise HTTPException(
+            status_code=503, detail="AI quest generation is not configured."
+        )
+
+    rate_limiter.check(
+        key=f"ai-quest-generate:{user.id}",
+        max_requests=_AI_QUEST_RATE_LIMIT_MAX_REQUESTS,
+        window_seconds=_AI_QUEST_RATE_LIMIT_WINDOW_SECONDS,
+    )
+
+    # Category names the model must choose from.
+    cat_result = await db.execute(select(ChoreCategory))
+    categories = cat_result.scalars().all()
+    category_names = [c.name for c in categories]
+
+    # Static examples preserve the fantasy tone without sending family-specific
+    # chore titles or descriptions to a third-party model.
+    example_block = _build_ai_example_block()
+    category_block = ", ".join(category_names) if category_names else "General"
+
+    system_instruction = (
+        "You are a quest writer for a family chore app that frames chores as "
+        "epic RPG/fantasy quests. Rewrite the parent's plain chore idea as a "
+        "single quest that matches the voice, tone, and style of the examples: "
+        "a short evocative fantasy title and a 1-2 sentence description that "
+        "renames ordinary household items and actions in medieval/fantasy terms "
+        "while keeping the real task clear. Pick the single best-fit category "
+        f"from this list (use the exact name): {category_block}. Suggest an XP "
+        "reward as a positive integer (easy chores ~10-15, medium ~20-25, hard "
+        "~30) and a difficulty of easy, medium, hard, or expert. Respond with "
+        "JSON only."
+    )
+    contents = (
+        f"Examples of the desired style:\n\n{example_block}\n\n"
+        f"Parent's chore idea: {body.prompt}"
+    )
+
+    try:
+        from google import genai
+        from google.genai import types
+
+        client = genai.Client(api_key=api_key)
+        response = await client.aio.models.generate_content(
+            model=_GEMINI_MODEL,
+            contents=contents,
+            config=types.GenerateContentConfig(
+                system_instruction=system_instruction,
+                response_mime_type="application/json",
+                response_schema=_GEMINI_RESPONSE_SCHEMA,
+                temperature=0.9,
+                max_output_tokens=600,
+            ),
+        )
+        import json
+
+        data = json.loads(response.text)
+    except Exception:
+        logger.exception("Gemini quest generation failed")
+        raise HTTPException(
+            status_code=502,
+            detail="The oracle could not be reached. Please try again.",
+        )
+
+    # Coerce / validate model output.
+    title = str(data.get("title") or "").strip()[:200]
+    description = str(data.get("description") or "").strip() or None
+    if not title:
+        raise HTTPException(
+            status_code=502, detail="The oracle returned an empty quest."
+        )
+
+    try:
+        points = int(data.get("points") or 10)
+    except (TypeError, ValueError):
+        points = 10
+    points = min(_AI_QUEST_MAX_POINTS, max(1, points))
+
+    raw_difficulty = str(data.get("difficulty") or "").lower()
+    try:
+        difficulty = Difficulty(raw_difficulty)
+    except ValueError:
+        difficulty = Difficulty.easy
+
+    # Resolve category name -> id (case-insensitive), mirroring the frontend.
+    category_name = str(data.get("category_name") or "").strip()
+    category_id = next(
+        (c.id for c in categories if c.name.lower() == category_name.lower()),
+        None,
+    )
+    if category_id is None and categories:
+        # Fall back to the first category so the form is still usable.
+        category_id = categories[0].id
+        category_name = categories[0].name
+
+    return QuestGenerateResponse(
+        title=title,
+        description=description,
+        points=points,
+        difficulty=difficulty,
+        category_name=category_name,
+        category_id=category_id,
+    )
 
 
 @router.get("/{chore_id}", response_model=ChoreResponse)

--- a/backend/routers/chores.py
+++ b/backend/routers/chores.py
@@ -1,10 +1,13 @@
 import logging
-import os
 import uuid
 from datetime import datetime, date, timezone, timedelta
 
 from backend.utils import utc_iso
-from backend.rate_limit import rate_limiter
+from backend.services.ai_provider import (
+    check_ai_generation_rate_limit,
+    generate_quest_draft,
+    get_ai_provider_config,
+)
 
 from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, File
 from sqlalchemy import select, and_, func, delete, text
@@ -20,7 +23,6 @@ from backend.models import (
     ChoreCategory,
     ChoreExclusion,
     ChoreRotation,
-    Difficulty,
     QuestTemplate,
     User,
     UserRole,
@@ -336,61 +338,8 @@ async def list_templates(
 
 
 # ---------------------------------------------------------------------------
-# AI quest generation (Google Gemini free tier)
+# AI quest generation
 # ---------------------------------------------------------------------------
-
-# Free-tier flash model — fast and no billing required.
-_GEMINI_MODEL = "gemini-2.0-flash"
-_AI_QUEST_RATE_LIMIT_MAX_REQUESTS = 5
-_AI_QUEST_RATE_LIMIT_WINDOW_SECONDS = 300
-_AI_QUEST_MAX_POINTS = 50
-
-# Fallback style anchors used only when the family has no chores yet.
-_SEED_STYLE_EXAMPLES = [
-    (
-        "The Chamber of Rest",
-        "Venture into your sleeping quarters and restore order to the land. "
-        "Make the bed, clear the floor, and banish the chaos that lurks within.",
-    ),
-    (
-        "Dishwasher's Oath",
-        "The enchanted basin overflows with relics of past feasts. Empty its "
-        "contents and return each vessel to its rightful place in the kingdom's cupboards.",
-    ),
-    (
-        "Beast Keeper's Round",
-        "The loyal creatures of the realm hunger for sustenance and care. Fill "
-        "their bowls, refresh their water, and tend to their domain.",
-    ),
-]
-
-_GEMINI_RESPONSE_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "title": {"type": "string"},
-        "description": {"type": "string"},
-        "points": {"type": "integer"},
-        "difficulty": {
-            "type": "string",
-            "enum": [d.value for d in Difficulty],
-        },
-        "category_name": {"type": "string"},
-    },
-    "required": ["title", "description", "points", "difficulty", "category_name"],
-}
-
-
-def gemini_enabled() -> bool:
-    """True when a Gemini API key is configured in the environment."""
-    return bool(os.environ.get("GEMINI_API_KEY"))
-
-
-def _build_ai_example_block() -> str:
-    """Use static style anchors so family chore data never leaves the app."""
-    return "\n\n".join(
-        f"Title: {title}\nDescription: {desc}"
-        for title, desc in _SEED_STYLE_EXAMPLES
-    )
 
 
 @router.post("/generate", response_model=QuestGenerateResponse)
@@ -405,109 +354,25 @@ async def generate_quest(
     saved — the parent reviews and edits in the create form, then saves via the
     normal POST /api/chores path.
     """
-    api_key = os.environ.get("GEMINI_API_KEY")
-    if not api_key:
-        raise HTTPException(
-            status_code=503, detail="AI quest generation is not configured."
-        )
-
-    rate_limiter.check(
-        key=f"ai-quest-generate:{user.id}",
-        max_requests=_AI_QUEST_RATE_LIMIT_MAX_REQUESTS,
-        window_seconds=_AI_QUEST_RATE_LIMIT_WINDOW_SECONDS,
-    )
+    check_ai_generation_rate_limit(user.id)
 
     # Category names the model must choose from.
     cat_result = await db.execute(select(ChoreCategory))
     categories = cat_result.scalars().all()
-    category_names = [c.name for c in categories]
-
-    # Static examples preserve the fantasy tone without sending family-specific
-    # chore titles or descriptions to a third-party model.
-    example_block = _build_ai_example_block()
-    category_block = ", ".join(category_names) if category_names else "General"
-
-    system_instruction = (
-        "You are a quest writer for a family chore app that frames chores as "
-        "epic RPG/fantasy quests. Rewrite the parent's plain chore idea as a "
-        "single quest that matches the voice, tone, and style of the examples: "
-        "a short evocative fantasy title and a 1-2 sentence description that "
-        "renames ordinary household items and actions in medieval/fantasy terms "
-        "while keeping the real task clear. Pick the single best-fit category "
-        f"from this list (use the exact name): {category_block}. Suggest an XP "
-        "reward as a positive integer (easy chores ~10-15, medium ~20-25, hard "
-        "~30) and a difficulty of easy, medium, hard, or expert. Respond with "
-        "JSON only."
+    config = await get_ai_provider_config(db)
+    data = await generate_quest_draft(
+        prompt=body.prompt,
+        categories=categories,
+        config=config,
     )
-    contents = (
-        f"Examples of the desired style:\n\n{example_block}\n\n"
-        f"Parent's chore idea: {body.prompt}"
-    )
-
-    try:
-        from google import genai
-        from google.genai import types
-
-        client = genai.Client(api_key=api_key)
-        response = await client.aio.models.generate_content(
-            model=_GEMINI_MODEL,
-            contents=contents,
-            config=types.GenerateContentConfig(
-                system_instruction=system_instruction,
-                response_mime_type="application/json",
-                response_schema=_GEMINI_RESPONSE_SCHEMA,
-                temperature=0.9,
-                max_output_tokens=600,
-            ),
-        )
-        import json
-
-        data = json.loads(response.text)
-    except Exception:
-        logger.exception("Gemini quest generation failed")
-        raise HTTPException(
-            status_code=502,
-            detail="The oracle could not be reached. Please try again.",
-        )
-
-    # Coerce / validate model output.
-    title = str(data.get("title") or "").strip()[:200]
-    description = str(data.get("description") or "").strip() or None
-    if not title:
-        raise HTTPException(
-            status_code=502, detail="The oracle returned an empty quest."
-        )
-
-    try:
-        points = int(data.get("points") or 10)
-    except (TypeError, ValueError):
-        points = 10
-    points = min(_AI_QUEST_MAX_POINTS, max(1, points))
-
-    raw_difficulty = str(data.get("difficulty") or "").lower()
-    try:
-        difficulty = Difficulty(raw_difficulty)
-    except ValueError:
-        difficulty = Difficulty.easy
-
-    # Resolve category name -> id (case-insensitive), mirroring the frontend.
-    category_name = str(data.get("category_name") or "").strip()
-    category_id = next(
-        (c.id for c in categories if c.name.lower() == category_name.lower()),
-        None,
-    )
-    if category_id is None and categories:
-        # Fall back to the first category so the form is still usable.
-        category_id = categories[0].id
-        category_name = categories[0].name
 
     return QuestGenerateResponse(
-        title=title,
-        description=description,
-        points=points,
-        difficulty=difficulty,
-        category_name=category_name,
-        category_id=category_id,
+        title=data["title"],
+        description=data["description"],
+        points=data["points"],
+        difficulty=data["difficulty"],
+        category_name=data["category_name"],
+        category_id=data["category_id"],
     )
 
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -540,6 +540,20 @@ class SettingsUpdate(BaseModel):
     settings: dict[str, str]
 
 
+class AISettingsUpdate(BaseModel):
+    provider: str = Field(min_length=1, max_length=20)
+    model: str = Field(min_length=1, max_length=100)
+    gemini_api_key: str | None = None
+    openai_api_key: str | None = None
+    anthropic_api_key: str | None = None
+    openai_organization: str | None = Field(default=None, max_length=100)
+    openai_project: str | None = Field(default=None, max_length=100)
+    ollama_base_url: str | None = Field(default=None, max_length=300)
+    clear_gemini_api_key: bool = False
+    clear_openai_api_key: bool = False
+    clear_anthropic_api_key: bool = False
+
+
 # Shoutouts
 class ShoutoutCreate(BaseModel):
     to_user_id: int

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -435,6 +435,22 @@ class QuestTemplateResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+# AI quest generation
+class QuestGenerateRequest(BaseModel):
+    # Plain-language chore idea, e.g. "clean the garage". Length-capped as the
+    # abuse guard (there is no rate-limit library in this repo).
+    prompt: str = Field(min_length=3, max_length=300)
+
+
+class QuestGenerateResponse(BaseModel):
+    title: str
+    description: str | None
+    points: int
+    difficulty: Difficulty
+    category_name: str
+    category_id: int | None
+
+
 # Rotations
 class RotationCreate(BaseModel):
     chore_id: int

--- a/backend/services/ai_provider.py
+++ b/backend/services/ai_provider.py
@@ -1,0 +1,488 @@
+import asyncio
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.models import AppSetting, ChoreCategory, Difficulty
+from backend.rate_limit import rate_limiter
+from backend.services.secure_settings import decrypt_secret, encrypt_secret
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PROVIDER = "gemini"
+DEFAULT_MODELS = {
+    "gemini": "gemini-2.0-flash",
+    "openai": "gpt-5.5-mini",
+    "anthropic": "claude-sonnet-4-5",
+    "ollama": "gemma3",
+}
+SUPPORTED_AI_PROVIDERS = tuple(DEFAULT_MODELS.keys())
+AI_QUEST_RATE_LIMIT_MAX_REQUESTS = 5
+AI_QUEST_RATE_LIMIT_WINDOW_SECONDS = 300
+AI_QUEST_MAX_POINTS = 50
+DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
+
+_SETTING_DEFAULTS = {
+    "ai_provider": DEFAULT_PROVIDER,
+    "ai_model": DEFAULT_MODELS[DEFAULT_PROVIDER],
+    "ai_openai_organization": "",
+    "ai_openai_project": "",
+    "ai_ollama_base_url": DEFAULT_OLLAMA_BASE_URL,
+}
+_SECRET_SETTING_KEYS = {
+    "gemini_api_key": "ai_gemini_api_key",
+    "openai_api_key": "ai_openai_api_key",
+    "anthropic_api_key": "ai_anthropic_api_key",
+}
+_SECRET_ENV_KEYS = {
+    "gemini_api_key": "GEMINI_API_KEY",
+    "openai_api_key": "OPENAI_API_KEY",
+    "anthropic_api_key": "ANTHROPIC_API_KEY",
+}
+_PROVIDER_REQUIRED_SECRET_FIELD = {
+    "gemini": "gemini_api_key",
+    "openai": "openai_api_key",
+    "anthropic": "anthropic_api_key",
+    "ollama": None,
+}
+_SEED_STYLE_EXAMPLES = [
+    (
+        "The Chamber of Rest",
+        "Venture into your sleeping quarters and restore order to the land. "
+        "Make the bed, clear the floor, and banish the chaos that lurks within.",
+    ),
+    (
+        "Dishwasher's Oath",
+        "The enchanted basin overflows with relics of past feasts. Empty its "
+        "contents and return each vessel to its rightful place in the kingdom's cupboards.",
+    ),
+    (
+        "Beast Keeper's Round",
+        "The loyal creatures of the realm hunger for sustenance and care. Fill "
+        "their bowls, refresh their water, and tend to their domain.",
+    ),
+]
+
+
+@dataclass
+class AIProviderConfig:
+    provider: str
+    model: str
+    gemini_api_key: str = ""
+    openai_api_key: str = ""
+    anthropic_api_key: str = ""
+    openai_organization: str = ""
+    openai_project: str = ""
+    ollama_base_url: str = DEFAULT_OLLAMA_BASE_URL
+
+    @property
+    def required_secret_field(self) -> str | None:
+        return _PROVIDER_REQUIRED_SECRET_FIELD.get(self.provider)
+
+    @property
+    def is_configured(self) -> bool:
+        if self.provider == "ollama":
+            return bool((self.ollama_base_url or "").strip() and self.model.strip())
+        secret_field = self.required_secret_field
+        if not secret_field:
+            return False
+        return bool(getattr(self, secret_field, "").strip() and self.model.strip())
+
+
+def _default_model_for(provider: str) -> str:
+    return DEFAULT_MODELS.get(provider, DEFAULT_MODELS[DEFAULT_PROVIDER])
+
+
+def _build_ai_example_block() -> str:
+    return "\n\n".join(
+        f"Title: {title}\nDescription: {desc}"
+        for title, desc in _SEED_STYLE_EXAMPLES
+    )
+
+
+async def _load_settings_map(db: AsyncSession) -> dict[str, str]:
+    keys = list(_SETTING_DEFAULTS.keys()) + list(_SECRET_SETTING_KEYS.values())
+    result = await db.execute(select(AppSetting).where(AppSetting.key.in_(keys)))
+    return {row.key: row.value for row in result.scalars().all()}
+
+
+def _decrypt_optional_secret(raw_value: str | None) -> str:
+    if not raw_value:
+        return ""
+    try:
+        return decrypt_secret(raw_value)
+    except ValueError:
+        logger.exception("Failed to decrypt stored AI provider secret")
+        return ""
+
+
+async def get_ai_provider_config(db: AsyncSession) -> AIProviderConfig:
+    stored = await _load_settings_map(db)
+    secret_values = {
+        public_key: (
+            os.environ.get(env_key)
+            or _decrypt_optional_secret(stored.get(setting_key))
+        )
+        for public_key, setting_key in _SECRET_SETTING_KEYS.items()
+        for env_key in [_SECRET_ENV_KEYS[public_key]]
+    }
+    provider = stored.get("ai_provider", _SETTING_DEFAULTS["ai_provider"]).strip() or DEFAULT_PROVIDER
+    if provider not in SUPPORTED_AI_PROVIDERS:
+        provider = DEFAULT_PROVIDER
+    model = stored.get("ai_model", "").strip() or _default_model_for(provider)
+    return AIProviderConfig(
+        provider=provider,
+        model=model,
+        gemini_api_key=secret_values["gemini_api_key"],
+        openai_api_key=secret_values["openai_api_key"],
+        anthropic_api_key=secret_values["anthropic_api_key"],
+        openai_organization=stored.get("ai_openai_organization", "").strip(),
+        openai_project=stored.get("ai_openai_project", "").strip(),
+        ollama_base_url=(
+            os.environ.get("OLLAMA_BASE_URL")
+            or stored.get("ai_ollama_base_url", DEFAULT_OLLAMA_BASE_URL).strip()
+            or DEFAULT_OLLAMA_BASE_URL
+        ),
+    )
+
+
+async def ai_generation_available(db: AsyncSession) -> bool:
+    config = await get_ai_provider_config(db)
+    return config.is_configured
+
+
+async def get_ai_settings_payload(db: AsyncSession) -> dict:
+    config = await get_ai_provider_config(db)
+    stored = await _load_settings_map(db)
+
+    def has_saved_secret(setting_key: str, env_key: str) -> bool:
+        return bool(os.environ.get(env_key) or stored.get(setting_key))
+
+    provider_states = {}
+    for provider in SUPPORTED_AI_PROVIDERS:
+        provider_states[provider] = {
+            "configured": (
+                provider == "ollama"
+                and bool(config.ollama_base_url.strip())
+            ) or (
+                _PROVIDER_REQUIRED_SECRET_FIELD[provider] is not None
+                and has_saved_secret(
+                    _SECRET_SETTING_KEYS[_PROVIDER_REQUIRED_SECRET_FIELD[provider]],
+                    _SECRET_ENV_KEYS[_PROVIDER_REQUIRED_SECRET_FIELD[provider]],
+                )
+            ),
+            "default_model": _default_model_for(provider),
+        }
+
+    return {
+        "provider": config.provider,
+        "model": config.model,
+        "openai_organization": config.openai_organization,
+        "openai_project": config.openai_project,
+        "ollama_base_url": config.ollama_base_url,
+        "providers": provider_states,
+        "active_provider_configured": config.is_configured,
+    }
+
+
+async def save_ai_settings(db: AsyncSession, body) -> dict:
+    provider = body.provider.strip().lower()
+    if provider not in SUPPORTED_AI_PROVIDERS:
+        raise HTTPException(status_code=400, detail="Unsupported AI provider")
+
+    values_to_write = {
+        "ai_provider": provider,
+        "ai_model": body.model.strip() or _default_model_for(provider),
+        "ai_openai_organization": (body.openai_organization or "").strip(),
+        "ai_openai_project": (body.openai_project or "").strip(),
+        "ai_ollama_base_url": (body.ollama_base_url or DEFAULT_OLLAMA_BASE_URL).strip(),
+    }
+
+    for key, value in values_to_write.items():
+        result = await db.execute(select(AppSetting).where(AppSetting.key == key))
+        existing = result.scalar_one_or_none()
+        if existing:
+            existing.value = value
+        else:
+            db.add(AppSetting(key=key, value=value))
+
+    secret_updates = {
+        "gemini_api_key": body.gemini_api_key,
+        "openai_api_key": body.openai_api_key,
+        "anthropic_api_key": body.anthropic_api_key,
+    }
+    secret_clears = {
+        "gemini_api_key": body.clear_gemini_api_key,
+        "openai_api_key": body.clear_openai_api_key,
+        "anthropic_api_key": body.clear_anthropic_api_key,
+    }
+
+    for public_key, setting_key in _SECRET_SETTING_KEYS.items():
+        result = await db.execute(select(AppSetting).where(AppSetting.key == setting_key))
+        existing = result.scalar_one_or_none()
+        if secret_clears[public_key]:
+            if existing:
+                await db.delete(existing)
+            continue
+        secret_value = (secret_updates[public_key] or "").strip()
+        if not secret_value:
+            continue
+        encrypted = encrypt_secret(secret_value)
+        if existing:
+            existing.value = encrypted
+        else:
+            db.add(AppSetting(key=setting_key, value=encrypted))
+
+    await db.commit()
+    return await get_ai_settings_payload(db)
+
+
+def check_ai_generation_rate_limit(user_id: int):
+    rate_limiter.check(
+        key=f"ai-quest-generate:{user_id}",
+        max_requests=AI_QUEST_RATE_LIMIT_MAX_REQUESTS,
+        window_seconds=AI_QUEST_RATE_LIMIT_WINDOW_SECONDS,
+    )
+
+
+async def generate_quest_draft(
+    *,
+    prompt: str,
+    categories: list[ChoreCategory],
+    config: AIProviderConfig,
+) -> dict:
+    if not config.is_configured:
+        raise HTTPException(
+            status_code=503,
+            detail="AI quest generation is not configured.",
+        )
+
+    category_names = [c.name for c in categories]
+    category_block = ", ".join(category_names) if category_names else "General"
+    system_instruction = (
+        "You are a quest writer for a family chore app that frames chores as "
+        "epic RPG/fantasy quests. Rewrite the parent's plain chore idea as a "
+        "single quest that matches the voice, tone, and style of the examples: "
+        "a short evocative fantasy title and a 1-2 sentence description that "
+        "renames ordinary household items and actions in medieval/fantasy terms "
+        "while keeping the real task clear. Pick the single best-fit category "
+        f"from this list (use the exact name): {category_block}. Suggest an XP "
+        "reward as a positive integer (easy chores ~10-15, medium ~20-25, hard "
+        "~30) and a difficulty of easy, medium, hard, or expert. Respond with "
+        "JSON only using keys title, description, points, difficulty, and category_name."
+    )
+    contents = (
+        f"Examples of the desired style:\n\n{_build_ai_example_block()}\n\n"
+        f"Parent's chore idea: {prompt}"
+    )
+
+    try:
+        if config.provider == "gemini":
+            data = await _generate_with_gemini(config, system_instruction, contents)
+        elif config.provider == "openai":
+            data = await asyncio.to_thread(
+                _generate_with_openai, config, system_instruction, contents
+            )
+        elif config.provider == "anthropic":
+            data = await asyncio.to_thread(
+                _generate_with_anthropic, config, system_instruction, contents
+            )
+        elif config.provider == "ollama":
+            data = await asyncio.to_thread(
+                _generate_with_ollama, config, system_instruction, contents
+            )
+        else:
+            raise HTTPException(status_code=400, detail="Unsupported AI provider")
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("AI quest generation failed for provider %s", config.provider)
+        raise HTTPException(
+            status_code=502,
+            detail="The oracle could not be reached. Please try again.",
+        )
+
+    return coerce_generated_quest(data, categories)
+
+
+def coerce_generated_quest(data: dict, categories: list[ChoreCategory]) -> dict:
+    title = str(data.get("title") or "").strip()[:200]
+    description = str(data.get("description") or "").strip() or None
+    if not title:
+        raise HTTPException(status_code=502, detail="The oracle returned an empty quest.")
+
+    try:
+        points = int(data.get("points") or 10)
+    except (TypeError, ValueError):
+        points = 10
+    points = min(AI_QUEST_MAX_POINTS, max(1, points))
+
+    raw_difficulty = str(data.get("difficulty") or "").lower()
+    try:
+        difficulty = Difficulty(raw_difficulty)
+    except ValueError:
+        difficulty = Difficulty.easy
+
+    category_name = str(data.get("category_name") or "").strip()
+    category_id = next(
+        (c.id for c in categories if c.name.lower() == category_name.lower()),
+        None,
+    )
+    if category_id is None and categories:
+        category_id = categories[0].id
+        category_name = categories[0].name
+
+    return {
+        "title": title,
+        "description": description,
+        "points": points,
+        "difficulty": difficulty,
+        "category_name": category_name,
+        "category_id": category_id,
+    }
+
+
+async def _generate_with_gemini(
+    config: AIProviderConfig,
+    system_instruction: str,
+    contents: str,
+) -> dict:
+    from google import genai
+    from google.genai import types
+
+    response_schema = {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "description": {"type": "string"},
+            "points": {"type": "integer"},
+            "difficulty": {
+                "type": "string",
+                "enum": [d.value for d in Difficulty],
+            },
+            "category_name": {"type": "string"},
+        },
+        "required": ["title", "description", "points", "difficulty", "category_name"],
+    }
+    client = genai.Client(api_key=config.gemini_api_key)
+    response = await client.aio.models.generate_content(
+        model=config.model,
+        contents=contents,
+        config=types.GenerateContentConfig(
+            system_instruction=system_instruction,
+            response_mime_type="application/json",
+            response_schema=response_schema,
+            temperature=0.9,
+            max_output_tokens=600,
+        ),
+    )
+    return json.loads(response.text)
+
+
+def _generate_with_openai(
+    config: AIProviderConfig,
+    system_instruction: str,
+    contents: str,
+) -> dict:
+    headers = {
+        "Authorization": f"Bearer {config.openai_api_key}",
+        "Content-Type": "application/json",
+    }
+    if config.openai_organization:
+        headers["OpenAI-Organization"] = config.openai_organization
+    if config.openai_project:
+        headers["OpenAI-Project"] = config.openai_project
+    payload = {
+        "model": config.model,
+        "instructions": system_instruction,
+        "input": contents,
+    }
+    data = _post_json("https://api.openai.com/v1/responses", payload, headers)
+    text = data.get("output_text")
+    if not text:
+        chunks = []
+        for item in data.get("output", []):
+            for content in item.get("content", []):
+                if isinstance(content, dict) and content.get("text"):
+                    chunks.append(content["text"])
+        text = "\n".join(chunks)
+    return _parse_json_text(text)
+
+
+def _generate_with_anthropic(
+    config: AIProviderConfig,
+    system_instruction: str,
+    contents: str,
+) -> dict:
+    payload = {
+        "model": config.model,
+        "max_tokens": 600,
+        "system": system_instruction,
+        "messages": [{"role": "user", "content": contents}],
+    }
+    headers = {
+        "x-api-key": config.anthropic_api_key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    }
+    data = _post_json("https://api.anthropic.com/v1/messages", payload, headers)
+    text = "\n".join(
+        part.get("text", "")
+        for part in data.get("content", [])
+        if isinstance(part, dict)
+    )
+    return _parse_json_text(text)
+
+
+def _generate_with_ollama(
+    config: AIProviderConfig,
+    system_instruction: str,
+    contents: str,
+) -> dict:
+    payload = {
+        "model": config.model,
+        "stream": False,
+        "format": "json",
+        "messages": [
+            {"role": "system", "content": system_instruction},
+            {"role": "user", "content": contents},
+        ],
+    }
+    base_url = config.ollama_base_url.rstrip("/")
+    data = _post_json(f"{base_url}/api/chat", payload, {"Content-Type": "application/json"})
+    text = data.get("message", {}).get("content", "")
+    return _parse_json_text(text)
+
+
+def _parse_json_text(text: str) -> dict:
+    if not text:
+        raise ValueError("Provider returned empty text")
+    text = text.strip()
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        raise ValueError("Provider returned non-JSON output")
+    return json.loads(text[start:end + 1])
+
+
+def _post_json(url: str, payload: dict, headers: dict[str, str]) -> dict:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="ignore")
+        logger.warning("AI provider HTTP error %s for %s: %s", exc.code, url, body)
+        raise

--- a/backend/services/secure_settings.py
+++ b/backend/services/secure_settings.py
@@ -1,0 +1,59 @@
+import base64
+import hashlib
+import hmac
+import secrets
+
+from backend.config import settings
+
+
+_ENCRYPTED_PREFIX = "enc:"
+_NONCE_LEN = 16
+_MAC_LEN = 32
+SENSITIVE_SETTING_KEYS = {
+    "vapid_private_key",
+    "ai_gemini_api_key",
+    "ai_openai_api_key",
+    "ai_anthropic_api_key",
+}
+
+
+def _key_bytes() -> bytes:
+    return hashlib.sha256(settings.SECRET_KEY.encode("utf-8")).digest()
+
+
+def _xor_keystream(data: bytes, nonce: bytes) -> bytes:
+    key = _key_bytes()
+    output = bytearray()
+    counter = 0
+    while len(output) < len(data):
+        block = hashlib.sha256(
+            key + nonce + counter.to_bytes(4, "big")
+        ).digest()
+        output.extend(block)
+        counter += 1
+    return bytes(a ^ b for a, b in zip(data, output[: len(data)]))
+
+
+def encrypt_secret(value: str) -> str:
+    plaintext = value.encode("utf-8")
+    nonce = secrets.token_bytes(_NONCE_LEN)
+    ciphertext = _xor_keystream(plaintext, nonce)
+    mac = hmac.new(_key_bytes(), nonce + ciphertext, hashlib.sha256).digest()
+    payload = base64.urlsafe_b64encode(nonce + ciphertext + mac).decode("ascii")
+    return f"{_ENCRYPTED_PREFIX}{payload}"
+
+
+def decrypt_secret(value: str) -> str:
+    if not value.startswith(_ENCRYPTED_PREFIX):
+        return value
+    raw = base64.urlsafe_b64decode(value[len(_ENCRYPTED_PREFIX):].encode("ascii"))
+    if len(raw) < _NONCE_LEN + _MAC_LEN:
+        raise ValueError("Stored secret payload is invalid")
+    nonce = raw[:_NONCE_LEN]
+    mac = raw[-_MAC_LEN:]
+    ciphertext = raw[_NONCE_LEN:-_MAC_LEN]
+    expected_mac = hmac.new(_key_bytes(), nonce + ciphertext, hashlib.sha256).digest()
+    if not hmac.compare_digest(mac, expected_mac):
+        raise ValueError("Stored secret payload failed integrity validation")
+    plaintext = _xor_keystream(ciphertext, nonce)
+    return plaintext.decode("utf-8")

--- a/frontend/src/components/QuestCreateModal.jsx
+++ b/frontend/src/components/QuestCreateModal.jsx
@@ -228,7 +228,7 @@ export default function QuestCreateModal({
               <div className="mt-3 space-y-2 border border-border rounded-lg p-3 bg-surface-raised/30">
                 <p className="text-muted text-xs">
                   Describe a chore in plain words and avoid names or private details.
-                  Uses Google Gemini to style it as a quest.
+                  Uses your configured AI provider to style it as a quest.
                 </p>
                 <p className="text-muted text-xs">
                   Up to 5 generations every 5 minutes. Suggested XP is capped for balance.

--- a/frontend/src/components/QuestCreateModal.jsx
+++ b/frontend/src/components/QuestCreateModal.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { api } from '../api/client';
 import { useTheme } from '../hooks/useTheme';
+import { useSettings } from '../hooks/useSettings';
 import { themedTitle, themedDescription } from '../utils/questThemeText';
 import Modal from './Modal';
 import {
@@ -8,6 +9,7 @@ import {
   Star,
   Scroll,
   CheckCircle2,
+  Sparkles,
 } from 'lucide-react';
 
 const DIFFICULTY_OPTIONS = [
@@ -38,12 +40,17 @@ export default function QuestCreateModal({
   editingChore,
 }) {
   const { colorTheme } = useTheme();
+  const { ai_quest_generation: aiEnabled } = useSettings();
   const [form, setForm] = useState({ ...emptyForm });
   const [formError, setFormError] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [templates, setTemplates] = useState([]);
   const [showTemplates, setShowTemplates] = useState(false);
   const [existingTitles, setExistingTitles] = useState(new Set());
+  const [showAi, setShowAi] = useState(false);
+  const [aiPrompt, setAiPrompt] = useState('');
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiError, setAiError] = useState('');
 
   useEffect(() => {
     if (isOpen) {
@@ -61,6 +68,9 @@ export default function QuestCreateModal({
       }
       setFormError('');
       setShowTemplates(false);
+      setShowAi(false);
+      setAiPrompt('');
+      setAiError('');
     }
   }, [isOpen, editingChore]);
 
@@ -97,6 +107,34 @@ export default function QuestCreateModal({
       category_id: catMatch ? String(catMatch.id) : '',
     });
     setShowTemplates(false);
+  };
+
+  const handleGenerate = async () => {
+    const prompt = aiPrompt.trim();
+    if (prompt.length < 3) {
+      setAiError('Describe the chore in a few words first.');
+      return;
+    }
+    setAiLoading(true);
+    setAiError('');
+    try {
+      const draft = await api('/api/chores/generate', {
+        method: 'POST',
+        body: { prompt },
+      });
+      setForm((prev) => ({
+        ...prev,
+        title: draft.title,
+        description: draft.description || '',
+        points: draft.points,
+        difficulty: draft.difficulty,
+        category_id: draft.category_id ? String(draft.category_id) : prev.category_id,
+      }));
+    } catch (err) {
+      setAiError(err.message || 'The oracle could not be reached. Please try again.');
+    } finally {
+      setAiLoading(false);
+    }
   };
 
   const handleSubmit = async () => {
@@ -171,6 +209,52 @@ export default function QuestCreateModal({
         {formError && (
           <div className="p-2 rounded border border-crimson/40 bg-crimson/10 text-crimson text-sm">
             {formError}
+          </div>
+        )}
+
+        {/* AI generate panel (only when creating + a Gemini key is configured) */}
+        {!editingChore && aiEnabled && (
+          <div>
+            <button
+              type="button"
+              onClick={() => setShowAi(!showAi)}
+              className="flex items-center gap-2 text-accent text-sm hover:text-accent/80 transition-colors"
+            >
+              <Sparkles size={14} />
+              {showAi ? 'Hide AI helper' : 'Generate with AI'}
+            </button>
+
+            {showAi && (
+              <div className="mt-3 space-y-2 border border-border rounded-lg p-3 bg-surface-raised/30">
+                <p className="text-muted text-xs">
+                  Describe a chore in plain words and avoid names or private details.
+                  Uses Google Gemini to style it as a quest.
+                </p>
+                <p className="text-muted text-xs">
+                  Up to 5 generations every 5 minutes. Suggested XP is capped for balance.
+                </p>
+                <textarea
+                  value={aiPrompt}
+                  onChange={(e) => setAiPrompt(e.target.value)}
+                  placeholder="e.g. clean the garage"
+                  rows={2}
+                  maxLength={300}
+                  className="field-input resize-none"
+                />
+                {aiError && (
+                  <p className="text-crimson text-xs">{aiError}</p>
+                )}
+                <button
+                  type="button"
+                  onClick={handleGenerate}
+                  disabled={aiLoading}
+                  className="game-btn game-btn-gold flex items-center gap-2"
+                >
+                  <Sparkles size={14} />
+                  {aiLoading ? 'Consulting the oracle...' : 'Generate Quest'}
+                </button>
+              </div>
+            )}
           </div>
         )}
 

--- a/frontend/src/hooks/useSettings.jsx
+++ b/frontend/src/hooks/useSettings.jsx
@@ -8,6 +8,7 @@ const SettingsContext = createContext({
   chore_trading_enabled: true,
   grace_period_days: 1,
   enable_debug_endpoints: false,
+  ai_quest_generation: false,
 });
 
 export function SettingsProvider({ children }) {
@@ -18,6 +19,7 @@ export function SettingsProvider({ children }) {
     chore_trading_enabled: true,
     grace_period_days: 1,
     enable_debug_endpoints: false,
+    ai_quest_generation: false,
   });
 
   const fetchFeatures = useCallback(async () => {
@@ -30,6 +32,7 @@ export function SettingsProvider({ children }) {
         chore_trading_enabled: data.chore_trading_enabled !== 'false',
         grace_period_days: parseInt(data.grace_period_days ?? '1', 10),
         enable_debug_endpoints: data.enable_debug_endpoints === 'true',
+        ai_quest_generation: data.ai_quest_generation === 'true',
       });
     } catch {
       // If fetch fails, keep defaults (all enabled)

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -19,8 +19,16 @@ import {
   Copy,
   Trash2,
   LayoutDashboard,
+  Sparkles,
 } from 'lucide-react';
 import VacationSettings from '../components/VacationSettings';
+
+const AI_PROVIDER_LABELS = {
+  gemini: 'Google Gemini',
+  openai: 'OpenAI GPT',
+  anthropic: 'Anthropic Claude',
+  ollama: 'Ollama',
+};
 
 function UpdatePanel({ isAdmin }) {
   const [version, setVersion] = useState(null);
@@ -221,6 +229,15 @@ export default function Settings() {
   const [dashboardToken, setDashboardToken] = useState(null);
   const [dashboardTokenLoading, setDashboardTokenLoading] = useState(false);
   const [dashboardCopied, setDashboardCopied] = useState(false);
+  const [aiSettings, setAiSettings] = useState(null);
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiSaving, setAiSaving] = useState(false);
+  const [aiSaveMsg, setAiSaveMsg] = useState('');
+  const [aiSecretInputs, setAiSecretInputs] = useState({
+    gemini_api_key: '',
+    openai_api_key: '',
+    anthropic_api_key: '',
+  });
 
   const fetchDashboardToken = useCallback(async () => {
     try {
@@ -309,16 +326,34 @@ export default function Settings() {
     }
   }, []);
 
+  const fetchAiSettings = useCallback(async () => {
+    setAiLoading(true);
+    try {
+      const data = await api('/api/admin/settings/ai');
+      setAiSettings({
+        ...data,
+        clear_gemini_api_key: false,
+        clear_openai_api_key: false,
+        clear_anthropic_api_key: false,
+      });
+    } catch {
+      setAiSettings(null);
+    } finally {
+      setAiLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     if (isParentOrAdmin) {
       fetchSettings();
       fetchAchievements();
       fetchDashboardToken();
+      fetchAiSettings();
     } else {
       setLoading(false);
       setError('Access denied. Only parents and admins can access settings.');
     }
-  }, [isParentOrAdmin, fetchSettings, fetchAchievements, fetchDashboardToken]);
+  }, [isParentOrAdmin, fetchSettings, fetchAchievements, fetchDashboardToken, fetchAiSettings]);
 
   const updateSetting = (key, value) => {
     setSettings((prev) => ({ ...prev, [key]: value }));
@@ -338,6 +373,77 @@ export default function Settings() {
       setTimeout(() => setSaveMsg(''), 3000);
     }
   };
+
+  const updateAiSetting = (key, value) => {
+    setAiSettings((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const updateAiSecretInput = (key, value) => {
+    setAiSecretInputs((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const saveAiSettings = async () => {
+    if (!aiSettings) return;
+    setAiSaving(true);
+    setAiSaveMsg('');
+    try {
+      const data = await api('/api/admin/settings/ai', {
+        method: 'PUT',
+        body: {
+          provider: aiSettings.provider,
+          model: aiSettings.model,
+          openai_organization: aiSettings.openai_organization || '',
+          openai_project: aiSettings.openai_project || '',
+          ollama_base_url: aiSettings.ollama_base_url || '',
+          gemini_api_key: aiSecretInputs.gemini_api_key || null,
+          openai_api_key: aiSecretInputs.openai_api_key || null,
+          anthropic_api_key: aiSecretInputs.anthropic_api_key || null,
+          clear_gemini_api_key: aiSettings.clear_gemini_api_key || false,
+          clear_openai_api_key: aiSettings.clear_openai_api_key || false,
+          clear_anthropic_api_key: aiSettings.clear_anthropic_api_key || false,
+        },
+      });
+      setAiSettings({
+        ...data,
+        clear_gemini_api_key: false,
+        clear_openai_api_key: false,
+        clear_anthropic_api_key: false,
+      });
+      setAiSecretInputs({
+        gemini_api_key: '',
+        openai_api_key: '',
+        anthropic_api_key: '',
+      });
+      setAiSaveMsg('AI settings saved!');
+      window.dispatchEvent(new CustomEvent('settings:updated'));
+    } catch (err) {
+      setAiSaveMsg(err.message || 'Failed to save AI settings');
+    } finally {
+      setAiSaving(false);
+      setTimeout(() => setAiSaveMsg(''), 4000);
+    }
+  };
+
+  const renderSecretField = (field, label, clearFlag) => (
+    <div className="space-y-2">
+      <label className="block text-cream text-sm">{label}</label>
+      <input
+        type="password"
+        value={aiSecretInputs[field]}
+        onChange={(e) => updateAiSecretInput(field, e.target.value)}
+        placeholder="Leave blank to keep current saved key"
+        className="field-input"
+      />
+      <label className="flex items-center gap-2 text-xs text-muted">
+        <input
+          type="checkbox"
+          checked={Boolean(aiSettings?.[clearFlag])}
+          onChange={(e) => updateAiSetting(clearFlag, e.target.checked)}
+        />
+        Clear saved key
+      </label>
+    </div>
+  );
 
   const updateAchievementPoints = async (achievement) => {
     setAchievementsSaving((prev) => ({ ...prev, [achievement.id]: true }));
@@ -457,6 +563,155 @@ export default function Settings() {
                 description="Enables /api/chores/{id}/debug for troubleshooting rotation and assignment issues. Requires parent login or API key."
               />
             </div>
+          </div>
+
+          <div className="game-panel p-4 space-y-4">
+            <div className="flex items-center gap-2">
+              <Sparkles size={16} className="text-accent" />
+              <h2 className="text-cream text-sm font-semibold">
+                AI Quest Generation
+              </h2>
+            </div>
+            <p className="text-muted text-xs leading-relaxed">
+              Choose which AI provider rewrites plain chores into quest text. Gemini stays the
+              default, but you can switch to OpenAI, Claude, or a local Ollama server.
+            </p>
+
+            {aiLoading && (
+              <div className="flex justify-center py-4">
+                <Loader2 size={20} className="text-accent animate-spin" />
+              </div>
+            )}
+
+            {!aiLoading && aiSettings && (
+              <div className="space-y-4">
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div>
+                    <label className="block text-cream text-sm mb-1">Provider</label>
+                    <select
+                      value={aiSettings.provider}
+                      onChange={(e) => {
+                        const nextProvider = e.target.value;
+                        updateAiSetting('provider', nextProvider);
+                        updateAiSetting(
+                          'model',
+                          aiSettings.providers?.[nextProvider]?.default_model || ''
+                        );
+                      }}
+                      className="field-input"
+                    >
+                      {Object.entries(AI_PROVIDER_LABELS).map(([value, label]) => (
+                        <option key={value} value={value}>{label}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-cream text-sm mb-1">Model</label>
+                    <input
+                      type="text"
+                      value={aiSettings.model || ''}
+                      onChange={(e) => updateAiSetting('model', e.target.value)}
+                      className="field-input"
+                    />
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  {Object.entries(AI_PROVIDER_LABELS).map(([provider, label]) => {
+                    const configured = aiSettings.providers?.[provider]?.configured;
+                    return (
+                      <span
+                        key={provider}
+                        className={`text-[11px] px-2 py-1 rounded-full border ${
+                          configured
+                            ? 'border-emerald/30 bg-emerald/10 text-emerald'
+                            : 'border-border bg-surface-raised/30 text-muted'
+                        }`}
+                      >
+                        {label}: {configured ? 'Configured' : 'Needs setup'}
+                      </span>
+                    );
+                  })}
+                </div>
+
+                {aiSettings.provider === 'gemini' && (
+                  <>
+                    {renderSecretField('gemini_api_key', 'Gemini API Key', 'clear_gemini_api_key')}
+                    <p className="text-muted text-xs">
+                      Uses Google Gemini with an API key. Best default option for the family app.
+                    </p>
+                  </>
+                )}
+
+                {aiSettings.provider === 'openai' && (
+                  <div className="space-y-3">
+                    {renderSecretField('openai_api_key', 'OpenAI API Key', 'clear_openai_api_key')}
+                    <div className="grid gap-3 md:grid-cols-2">
+                      <div>
+                        <label className="block text-cream text-sm mb-1">Organization (optional)</label>
+                        <input
+                          type="text"
+                          value={aiSettings.openai_organization || ''}
+                          onChange={(e) => updateAiSetting('openai_organization', e.target.value)}
+                          className="field-input"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-cream text-sm mb-1">Project (optional)</label>
+                        <input
+                          type="text"
+                          value={aiSettings.openai_project || ''}
+                          onChange={(e) => updateAiSetting('openai_project', e.target.value)}
+                          className="field-input"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {aiSettings.provider === 'anthropic' && (
+                  <>
+                    {renderSecretField('anthropic_api_key', 'Anthropic API Key', 'clear_anthropic_api_key')}
+                    <p className="text-muted text-xs">
+                      Uses Claude via Anthropic&apos;s API. The app sends the required API version header automatically.
+                    </p>
+                  </>
+                )}
+
+                {aiSettings.provider === 'ollama' && (
+                  <div className="space-y-2">
+                    <label className="block text-cream text-sm">Ollama Base URL</label>
+                    <input
+                      type="text"
+                      value={aiSettings.ollama_base_url || ''}
+                      onChange={(e) => updateAiSetting('ollama_base_url', e.target.value)}
+                      className="field-input"
+                    />
+                    <p className="text-muted text-xs">
+                      Typical local value is http://localhost:11434. No API key is required unless your proxy adds one.
+                    </p>
+                  </div>
+                )}
+
+                <button
+                  onClick={saveAiSettings}
+                  disabled={aiSaving}
+                  className="game-btn game-btn-gold flex items-center gap-2"
+                >
+                  {aiSaving ? (
+                    <Loader2 size={14} className="animate-spin" />
+                  ) : (
+                    <Save size={14} />
+                  )}
+                  {aiSaving ? 'Saving AI Settings...' : 'Save AI Provider'}
+                </button>
+                {aiSaveMsg && (
+                  <p className={`text-sm ${aiSaveMsg.includes('!') ? 'text-emerald' : 'text-crimson'}`}>
+                    {aiSaveMsg}
+                  </p>
+                )}
+              </div>
+            )}
           </div>
 
           {/* Daily reset hour */}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ bcrypt==4.2.1
 python-multipart==0.0.27
 pywebpush==2.3.0
 cryptography==47.0.0
-google-genai==2.9.0
+google-genai==2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ bcrypt==4.2.1
 python-multipart==0.0.27
 pywebpush==2.3.0
 cryptography==47.0.0
+google-genai==2.9.0

--- a/tests/unit/test_ai_provider_settings.py
+++ b/tests/unit/test_ai_provider_settings.py
@@ -1,0 +1,127 @@
+import pytest
+
+from fastapi import HTTPException
+
+from backend.models import AppSetting, UserRole
+from backend.services.ai_provider import (
+    AIProviderConfig,
+    ai_generation_available,
+    coerce_generated_quest,
+    get_ai_provider_config,
+    get_ai_settings_payload,
+    save_ai_settings,
+)
+from backend.services.secure_settings import decrypt_secret
+from backend.schemas import AISettingsUpdate
+from tests.unit.conftest import make_category, make_user
+
+
+@pytest.mark.asyncio
+async def test_ai_settings_save_encrypts_secret_and_masks_response(db):
+    await make_user(db, "settings_parent1", role=UserRole.parent)
+
+    payload = await save_ai_settings(
+        db,
+        AISettingsUpdate(
+            provider="openai",
+            model="gpt-5.5-mini",
+            openai_api_key="sk-test-123",
+            openai_organization="org_123",
+            openai_project="proj_123",
+        ),
+    )
+
+    stored = await db.get(AppSetting, "ai_openai_api_key")
+    assert stored is not None
+    assert stored.value != "sk-test-123"
+    assert decrypt_secret(stored.value) == "sk-test-123"
+    assert payload["providers"]["openai"]["configured"] is True
+    assert "openai_api_key" not in payload
+
+
+@pytest.mark.asyncio
+async def test_ai_settings_loads_env_override_for_gemini(db, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "env-gemini-key")
+
+    config = await get_ai_provider_config(db)
+
+    assert config.provider == "gemini"
+    assert config.gemini_api_key == "env-gemini-key"
+    assert config.is_configured is True
+
+
+@pytest.mark.asyncio
+async def test_ai_generation_available_reflects_selected_provider(db):
+    assert await ai_generation_available(db) is False
+
+    await save_ai_settings(
+        db,
+        AISettingsUpdate(
+            provider="ollama",
+            model="llama3.1",
+            ollama_base_url="http://127.0.0.1:11434",
+        ),
+    )
+
+    assert await ai_generation_available(db) is True
+
+
+@pytest.mark.asyncio
+async def test_save_ai_settings_can_clear_secret(db):
+    await save_ai_settings(
+        db,
+        AISettingsUpdate(
+            provider="anthropic",
+            model="claude-sonnet-4-5",
+            anthropic_api_key="secret-key",
+        ),
+    )
+
+    payload = await save_ai_settings(
+        db,
+        AISettingsUpdate(
+            provider="anthropic",
+            model="claude-sonnet-4-5",
+            clear_anthropic_api_key=True,
+        ),
+    )
+
+    assert await db.get(AppSetting, "ai_anthropic_api_key") is None
+    assert payload["providers"]["anthropic"]["configured"] is False
+
+
+@pytest.mark.asyncio
+async def test_coerce_generated_quest_caps_points_and_defaults_category(db):
+    category = await make_category(db, "Kitchen")
+
+    data = coerce_generated_quest(
+        {
+            "title": "Pantry Patrol",
+            "description": "Organize the shelf.",
+            "points": 999,
+            "difficulty": "medium",
+            "category_name": "Unknown",
+        },
+        [category],
+    )
+
+    assert data["points"] == 50
+    assert data["category_id"] == category.id
+    assert data["category_name"] == "Kitchen"
+
+
+@pytest.mark.asyncio
+async def test_coerce_generated_quest_requires_non_empty_title(db):
+    with pytest.raises(HTTPException) as exc_info:
+        coerce_generated_quest(
+            {
+                "title": "",
+                "description": "desc",
+                "points": 10,
+                "difficulty": "easy",
+                "category_name": "",
+            },
+            [],
+        )
+
+    assert exc_info.value.status_code == 502

--- a/tests/unit/test_ai_quest_generation.py
+++ b/tests/unit/test_ai_quest_generation.py
@@ -1,0 +1,153 @@
+import json
+import sys
+import types
+
+import pytest
+from fastapi import HTTPException
+
+from backend.models import Difficulty, UserRole
+from backend.rate_limit import rate_limiter
+from backend.routers.chores import generate_quest
+from backend.schemas import QuestGenerateRequest
+from tests.unit.conftest import make_category, make_chore, make_user
+
+
+def _install_fake_google(monkeypatch, response_payload, captured):
+    class FakeGenerateContentConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeModels:
+        async def generate_content(self, *, model, contents, config):
+            captured["model"] = model
+            captured["contents"] = contents
+            captured["config"] = config
+            return types.SimpleNamespace(text=json.dumps(response_payload))
+
+    class FakeClient:
+        def __init__(self, api_key):
+            captured["api_key"] = api_key
+            self.aio = types.SimpleNamespace(models=FakeModels())
+
+    google_module = types.ModuleType("google")
+    genai_module = types.ModuleType("google.genai")
+    genai_module.Client = FakeClient
+    genai_module.types = types.SimpleNamespace(
+        GenerateContentConfig=FakeGenerateContentConfig
+    )
+    google_module.genai = genai_module
+
+    monkeypatch.setitem(sys.modules, "google", google_module)
+    monkeypatch.setitem(sys.modules, "google.genai", genai_module)
+
+
+@pytest.mark.asyncio
+async def test_generate_quest_does_not_send_existing_family_chores(db, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+    rate_limiter._windows.clear()
+
+    parent = await make_user(db, "parent_ai", role=UserRole.parent)
+    category = await make_category(db, "Kitchen")
+    private_title = "Clean Ava's inhaler station"
+    private_description = "Wipe the medicine tray beside Ava's bed."
+    chore = await make_chore(
+        db,
+        creator_id=parent.id,
+        category_id=category.id,
+        title=private_title,
+    )
+    chore.description = private_description
+    await db.flush()
+
+    captured = {}
+    _install_fake_google(
+        monkeypatch,
+        {
+            "title": "Cupboard Crusade",
+            "description": "Restore order to the snack shelf.",
+            "points": 20,
+            "difficulty": "medium",
+            "category_name": "Kitchen",
+        },
+        captured,
+    )
+
+    response = await generate_quest(
+        QuestGenerateRequest(prompt="organize the snack shelf"),
+        db=db,
+        user=parent,
+    )
+
+    assert response.title == "Cupboard Crusade"
+    assert private_title not in captured["contents"]
+    assert private_description not in captured["contents"]
+    assert "The Chamber of Rest" in captured["contents"]
+
+
+@pytest.mark.asyncio
+async def test_generate_quest_caps_ai_points_to_safe_max(db, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+    rate_limiter._windows.clear()
+
+    parent = await make_user(db, "parent_cap", role=UserRole.parent)
+    await make_category(db, "General")
+
+    captured = {}
+    _install_fake_google(
+        monkeypatch,
+        {
+            "title": "Dragon Hoard Sort",
+            "description": "Sort the toy bin.",
+            "points": 9999,
+            "difficulty": "expert",
+            "category_name": "General",
+        },
+        captured,
+    )
+
+    response = await generate_quest(
+        QuestGenerateRequest(prompt="sort the toy bin"),
+        db=db,
+        user=parent,
+    )
+
+    assert response.points == 50
+    assert response.difficulty == Difficulty.expert
+
+
+@pytest.mark.asyncio
+async def test_generate_quest_rate_limits_per_parent(db, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+    rate_limiter._windows.clear()
+
+    parent = await make_user(db, "parent_limit", role=UserRole.parent)
+    await make_category(db, "General")
+
+    captured = {}
+    _install_fake_google(
+        monkeypatch,
+        {
+            "title": "Lantern Patrol",
+            "description": "Put away the hallway clutter.",
+            "points": 10,
+            "difficulty": "easy",
+            "category_name": "General",
+        },
+        captured,
+    )
+
+    for _ in range(5):
+        await generate_quest(
+            QuestGenerateRequest(prompt="put away hallway clutter"),
+            db=db,
+            user=parent,
+        )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await generate_quest(
+            QuestGenerateRequest(prompt="put away hallway clutter"),
+            db=db,
+            user=parent,
+        )
+
+    assert exc_info.value.status_code == 429


### PR DESCRIPTION
## What this adds
Parents can describe a chore in plain words and have it rewritten as an on-style RPG quest (title, description, suggested XP/difficulty/category), pre-filled into the create form for review before saving. Nothing is auto-saved — it reuses the normal `POST /api/chores` path.

- **Configurable AI providers:** Google Gemini, OpenAI, Anthropic Claude, and Ollama (local).
- **In-app config:** Settings → AI Quest Generation. API keys are stored encrypted (`backend/services/secure_settings.py`) and never returned to the browser.
- **Safety:** per-parent rate limit (5 / 5 min, via the existing `SlidingWindowRateLimiter`) and an XP cap (50).
- **Privacy:** uses static seed style examples only — family chore text is not sent to third-party APIs.

## Commits
- `feat: add safer AI quest generation` — endpoint, schemas, modal UI, tests
- `feat: add configurable AI quest providers` — provider abstraction (`ai_provider.py`), encrypted settings, Settings UI
- `fix: pin google-genai to 2.8.0 for pydantic compatibility` — **build blocker fix** (see below)
- `docs: document AI-assisted quest creation`

## ⚠️ Build-blocker fixed in this PR
`google-genai==2.9.0` requires `pydantic>=2.12.5`, which conflicts with the pinned `pydantic==2.10.4` → `pip install -r requirements.txt` failed with `ResolutionImpossible`, breaking the Docker build. Repinned to `google-genai==2.8.0` (requires only `pydantic>=2.9.0`, same async API surface). Verified locally on Python 3.13: clean resolution + **all 119 unit tests pass**.

## Review notes (open, non-blocking)
- **Behavior change vs. original plan:** style anchoring switched from the family's own chores → static seed examples (privacy tradeoff; slightly less tailored output).
- **Hand-rolled crypto** in `secure_settings.py` (SHA-256 XOR stream + HMAC). Functionally sound, but `cryptography` (Fernet) is already a dependency — candidate for a follow-up swap.
- **Minor SSRF surface:** `ollama_base_url` is an admin-settable URL the server POSTs to (parent/admin-gated).

## Verification
- `pip install -r requirements.txt` resolves cleanly; routers/services import without error.
- 119/119 backend unit tests pass (9 new AI tests).
- Frontend builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)