### PR TITLE
fix: align Gemini integration with current docs

### DIFF
--- a/backend/services/ai_provider.py
+++ b/backend/services/ai_provider.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_PROVIDER = "gemini"
 DEFAULT_MODELS = {
-    "gemini": "gemini-2.0-flash",
+    "gemini": "gemini-3.5-flash",
     "openai": "gpt-5.5-mini",
     "anthropic": "claude-sonnet-4-5",
     "ollama": "gemma3",
@@ -340,12 +340,9 @@ async def generate_quest_draft(
             raise HTTPException(status_code=400, detail="Unsupported AI provider")
     except HTTPException:
         raise
-    except Exception:
+    except Exception as exc:
         logger.exception("AI quest generation failed for provider %s", config.provider)
-        raise HTTPException(
-            status_code=502,
-            detail="The oracle could not be reached. Please try again.",
-        )
+        raise _map_ai_provider_error(config.provider, exc)
 
     return coerce_generated_quest(data, categories)
 
@@ -393,7 +390,6 @@ async def _generate_with_gemini(
     contents: str,
 ) -> dict:
     from google import genai
-    from google.genai import types
 
     response_schema = {
         "type": "object",
@@ -410,18 +406,22 @@ async def _generate_with_gemini(
         "required": ["title", "description", "points", "difficulty", "category_name"],
     }
     client = genai.Client(api_key=config.gemini_api_key)
-    response = await client.aio.models.generate_content(
+    interaction = await client.aio.interactions.create(
         model=config.model,
-        contents=contents,
-        config=types.GenerateContentConfig(
-            system_instruction=system_instruction,
-            response_mime_type="application/json",
-            response_schema=response_schema,
-            temperature=0.9,
-            max_output_tokens=600,
-        ),
+        input=contents,
+        system_instruction=system_instruction,
+        response_format={
+            "type": "text",
+            "mime_type": "application/json",
+            "schema": response_schema,
+        },
+        generation_config={
+            "temperature": 0.9,
+            "max_output_tokens": 600,
+            "thinking_level": "low",
+        },
     )
-    return json.loads(response.text)
+    return json.loads(interaction.output_text)
 
 
 def _generate_with_openai(
@@ -524,3 +524,28 @@ def _post_json(url: str, payload: dict, headers: dict[str, str]) -> dict:
         body = exc.read().decode("utf-8", errors="ignore")
         logger.warning("AI provider HTTP error %s for %s: %s", exc.code, url, body)
         raise
+
+
+def _map_ai_provider_error(provider: str, exc: Exception) -> HTTPException:
+    text = str(exc)
+    lower = text.lower()
+    if provider == "gemini":
+        if "429" in text and "resource_exhausted" in lower:
+            return HTTPException(
+                status_code=503,
+                detail="Gemini quota exceeded. Update the Gemini key/project or switch providers.",
+            )
+        if "404" in text and "no longer available" in lower:
+            return HTTPException(
+                status_code=503,
+                detail="The configured Gemini model is no longer available. Choose a current Gemini model in Family Settings.",
+            )
+        if "401" in text or "403" in text:
+            return HTTPException(
+                status_code=503,
+                detail="Gemini rejected the API key. Check the saved Gemini key and its project restrictions.",
+            )
+    return HTTPException(
+        status_code=502,
+        detail="The oracle could not be reached. Please try again.",
+    )

--- a/backend/services/secure_settings.py
+++ b/backend/services/secure_settings.py
@@ -1,14 +1,12 @@
 import base64
 import hashlib
-import hmac
-import secrets
+
+from cryptography.fernet import Fernet, InvalidToken
 
 from backend.config import settings
 
 
 _ENCRYPTED_PREFIX = "enc:"
-_NONCE_LEN = 16
-_MAC_LEN = 32
 SENSITIVE_SETTING_KEYS = {
     "vapid_private_key",
     "ai_gemini_api_key",
@@ -17,43 +15,21 @@ SENSITIVE_SETTING_KEYS = {
 }
 
 
-def _key_bytes() -> bytes:
-    return hashlib.sha256(settings.SECRET_KEY.encode("utf-8")).digest()
-
-
-def _xor_keystream(data: bytes, nonce: bytes) -> bytes:
-    key = _key_bytes()
-    output = bytearray()
-    counter = 0
-    while len(output) < len(data):
-        block = hashlib.sha256(
-            key + nonce + counter.to_bytes(4, "big")
-        ).digest()
-        output.extend(block)
-        counter += 1
-    return bytes(a ^ b for a, b in zip(data, output[: len(data)]))
+def _fernet() -> Fernet:
+    key = hashlib.sha256(settings.SECRET_KEY.encode("utf-8")).digest()
+    return Fernet(base64.urlsafe_b64encode(key))
 
 
 def encrypt_secret(value: str) -> str:
-    plaintext = value.encode("utf-8")
-    nonce = secrets.token_bytes(_NONCE_LEN)
-    ciphertext = _xor_keystream(plaintext, nonce)
-    mac = hmac.new(_key_bytes(), nonce + ciphertext, hashlib.sha256).digest()
-    payload = base64.urlsafe_b64encode(nonce + ciphertext + mac).decode("ascii")
-    return f"{_ENCRYPTED_PREFIX}{payload}"
+    token = _fernet().encrypt(value.encode("utf-8"))
+    return f"{_ENCRYPTED_PREFIX}{token.decode('ascii')}"
 
 
 def decrypt_secret(value: str) -> str:
     if not value.startswith(_ENCRYPTED_PREFIX):
         return value
-    raw = base64.urlsafe_b64decode(value[len(_ENCRYPTED_PREFIX):].encode("ascii"))
-    if len(raw) < _NONCE_LEN + _MAC_LEN:
-        raise ValueError("Stored secret payload is invalid")
-    nonce = raw[:_NONCE_LEN]
-    mac = raw[-_MAC_LEN:]
-    ciphertext = raw[_NONCE_LEN:-_MAC_LEN]
-    expected_mac = hmac.new(_key_bytes(), nonce + ciphertext, hashlib.sha256).digest()
-    if not hmac.compare_digest(mac, expected_mac):
+    token = value[len(_ENCRYPTED_PREFIX):].encode("ascii")
+    try:
+        return _fernet().decrypt(token).decode("utf-8")
+    except InvalidToken:
         raise ValueError("Stored secret payload failed integrity validation")
-    plaintext = _xor_keystream(ciphertext, nonce)
-    return plaintext.decode("utf-8")

--- a/backend/services/secure_settings.py
+++ b/backend/services/secure_settings.py
@@ -1,12 +1,14 @@
 import base64
 import hashlib
-
-from cryptography.fernet import Fernet, InvalidToken
+import hmac
+import secrets
 
 from backend.config import settings
 
 
 _ENCRYPTED_PREFIX = "enc:"
+_NONCE_LEN = 16
+_MAC_LEN = 32
 SENSITIVE_SETTING_KEYS = {
     "vapid_private_key",
     "ai_gemini_api_key",
@@ -15,21 +17,43 @@ SENSITIVE_SETTING_KEYS = {
 }
 
 
-def _fernet() -> Fernet:
-    key = hashlib.sha256(settings.SECRET_KEY.encode("utf-8")).digest()
-    return Fernet(base64.urlsafe_b64encode(key))
+def _key_bytes() -> bytes:
+    return hashlib.sha256(settings.SECRET_KEY.encode("utf-8")).digest()
+
+
+def _xor_keystream(data: bytes, nonce: bytes) -> bytes:
+    key = _key_bytes()
+    output = bytearray()
+    counter = 0
+    while len(output) < len(data):
+        block = hashlib.sha256(
+            key + nonce + counter.to_bytes(4, "big")
+        ).digest()
+        output.extend(block)
+        counter += 1
+    return bytes(a ^ b for a, b in zip(data, output[: len(data)]))
 
 
 def encrypt_secret(value: str) -> str:
-    token = _fernet().encrypt(value.encode("utf-8"))
-    return f"{_ENCRYPTED_PREFIX}{token.decode('ascii')}"
+    plaintext = value.encode("utf-8")
+    nonce = secrets.token_bytes(_NONCE_LEN)
+    ciphertext = _xor_keystream(plaintext, nonce)
+    mac = hmac.new(_key_bytes(), nonce + ciphertext, hashlib.sha256).digest()
+    payload = base64.urlsafe_b64encode(nonce + ciphertext + mac).decode("ascii")
+    return f"{_ENCRYPTED_PREFIX}{payload}"
 
 
 def decrypt_secret(value: str) -> str:
     if not value.startswith(_ENCRYPTED_PREFIX):
         return value
-    token = value[len(_ENCRYPTED_PREFIX):].encode("ascii")
-    try:
-        return _fernet().decrypt(token).decode("utf-8")
-    except InvalidToken:
+    raw = base64.urlsafe_b64decode(value[len(_ENCRYPTED_PREFIX):].encode("ascii"))
+    if len(raw) < _NONCE_LEN + _MAC_LEN:
+        raise ValueError("Stored secret payload is invalid")
+    nonce = raw[:_NONCE_LEN]
+    mac = raw[-_MAC_LEN:]
+    ciphertext = raw[_NONCE_LEN:-_MAC_LEN]
+    expected_mac = hmac.new(_key_bytes(), nonce + ciphertext, hashlib.sha256).digest()
+    if not hmac.compare_digest(mac, expected_mac):
         raise ValueError("Stored secret payload failed integrity validation")
+    plaintext = _xor_keystream(ciphertext, nonce)
+    return plaintext.decode("utf-8")

--- a/tests/unit/test_ai_provider_settings.py
+++ b/tests/unit/test_ai_provider_settings.py
@@ -5,6 +5,8 @@ from fastapi import HTTPException
 from backend.models import AppSetting, UserRole
 from backend.services.ai_provider import (
     AIProviderConfig,
+    DEFAULT_MODELS,
+    _map_ai_provider_error,
     ai_generation_available,
     coerce_generated_quest,
     get_ai_provider_config,
@@ -46,6 +48,7 @@ async def test_ai_settings_loads_env_override_for_gemini(db, monkeypatch):
     config = await get_ai_provider_config(db)
 
     assert config.provider == "gemini"
+    assert config.model == DEFAULT_MODELS["gemini"]
     assert config.gemini_api_key == "env-gemini-key"
     assert config.is_configured is True
 
@@ -125,3 +128,21 @@ async def test_coerce_generated_quest_requires_non_empty_title(db):
         )
 
     assert exc_info.value.status_code == 502
+
+
+def test_map_ai_provider_error_for_gemini_quota():
+    error = _map_ai_provider_error(
+        "gemini",
+        RuntimeError("429 RESOURCE_EXHAUSTED quota exceeded"),
+    )
+    assert error.status_code == 503
+    assert "quota exceeded" in error.detail.lower()
+
+
+def test_map_ai_provider_error_for_gemini_retired_model():
+    error = _map_ai_provider_error(
+        "gemini",
+        RuntimeError("404 NOT_FOUND model is no longer available"),
+    )
+    assert error.status_code == 503
+    assert "no longer available" in error.detail.lower()

--- a/tests/unit/test_ai_quest_generation.py
+++ b/tests/unit/test_ai_quest_generation.py
@@ -13,28 +13,31 @@ from tests.unit.conftest import make_category, make_chore, make_user
 
 
 def _install_fake_google(monkeypatch, response_payload, captured):
-    class FakeGenerateContentConfig:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
-
-    class FakeModels:
-        async def generate_content(self, *, model, contents, config):
+    class FakeInteractions:
+        async def create(
+            self,
+            *,
+            model,
+            input,
+            system_instruction,
+            response_format,
+            generation_config,
+        ):
             captured["model"] = model
-            captured["contents"] = contents
-            captured["config"] = config
-            return types.SimpleNamespace(text=json.dumps(response_payload))
+            captured["contents"] = input
+            captured["system_instruction"] = system_instruction
+            captured["response_format"] = response_format
+            captured["generation_config"] = generation_config
+            return types.SimpleNamespace(output_text=json.dumps(response_payload))
 
     class FakeClient:
         def __init__(self, api_key):
             captured["api_key"] = api_key
-            self.aio = types.SimpleNamespace(models=FakeModels())
+            self.aio = types.SimpleNamespace(interactions=FakeInteractions())
 
     google_module = types.ModuleType("google")
     genai_module = types.ModuleType("google.genai")
     genai_module.Client = FakeClient
-    genai_module.types = types.SimpleNamespace(
-        GenerateContentConfig=FakeGenerateContentConfig
-    )
     google_module.genai = genai_module
 
     monkeypatch.setitem(sys.modules, "google", google_module)


### PR DESCRIPTION
## Summary
- switch the Gemini adapter from the older generate_content path to the current Interactions API flow
- update the default Gemini model from the retired gemini-2.0-flash to the current stable gemini-3.5-flash
- map Gemini quota and retired-model failures to clearer user-facing errors
- keep focused test coverage around provider defaults and Gemini error mapping

## Why
Google's current official Gemini docs recommend the Interactions API for access to the latest features and models, and the official model list shows Gemini 2.0 Flash as shut down.

## Testing
- pytest tests/unit/test_ai_provider_settings.py tests/unit/test_ai_quest_generation.py
- python3 -m compileall backend
- npm run build
