### PR TITLE
feat: AI model dropdowns + validate-on-save (all providers) + correct defaults

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -23,10 +23,16 @@ from backend.schemas import (
     AuditLogResponse,
     SettingsUpdate,
     AISettingsUpdate,
+    AIModelListRequest,
 )
 from backend.auth import hash_password
 from backend.dependencies import require_admin, require_parent, get_current_user
-from backend.services.ai_provider import get_ai_settings_payload, save_ai_settings, ai_generation_available
+from backend.services.ai_provider import (
+    get_ai_settings_payload,
+    save_ai_settings,
+    ai_generation_available,
+    list_models_for_request,
+)
 from backend.services.secure_settings import SENSITIVE_SETTING_KEYS
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
@@ -348,6 +354,20 @@ async def update_ai_settings(
     _parent: User = Depends(require_parent),
 ):
     return await save_ai_settings(db, body)
+
+
+@router.post("/settings/ai/models")
+async def list_ai_models(
+    body: AIModelListRequest,
+    db: AsyncSession = Depends(get_db),
+    _parent: User = Depends(require_parent),
+):
+    """List available models for a provider (for the Settings dropdown).
+
+    Accepts an optional, not-yet-saved API key so the UI can load models right
+    after a key is typed, before it is persisted.
+    """
+    return {"models": await list_models_for_request(db, body)}
 
 
 # ---------- PUT /settings ----------

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -554,6 +554,18 @@ class AISettingsUpdate(BaseModel):
     clear_anthropic_api_key: bool = False
 
 
+class AIModelListRequest(BaseModel):
+    # Request to list available models for a provider. Optional secret/url
+    # fields let the UI load models with a freshly-typed (unsaved) key.
+    provider: str = Field(min_length=1, max_length=20)
+    gemini_api_key: str | None = None
+    openai_api_key: str | None = None
+    anthropic_api_key: str | None = None
+    openai_organization: str | None = Field(default=None, max_length=100)
+    openai_project: str | None = Field(default=None, max_length=100)
+    ollama_base_url: str | None = Field(default=None, max_length=300)
+
+
 # Shoutouts
 class ShoutoutCreate(BaseModel):
     to_user_id: int

--- a/backend/services/ai_provider.py
+++ b/backend/services/ai_provider.py
@@ -21,7 +21,7 @@ DEFAULT_PROVIDER = "gemini"
 DEFAULT_MODELS = {
     "gemini": "gemini-flash-latest",
     "openai": "gpt-5.5-mini",
-    "anthropic": "claude-sonnet-4-5",
+    "anthropic": "claude-haiku-4-5",
     "ollama": "gemma3",
 }
 SUPPORTED_AI_PROVIDERS = tuple(DEFAULT_MODELS.keys())
@@ -278,6 +278,17 @@ async def save_ai_settings(db: AsyncSession, body) -> dict:
         else:
             db.add(AppSetting(key=setting_key, value=encrypted))
 
+    # Validate the resulting config against the live provider before persisting,
+    # so a model/key that won't work is rejected with an actionable message
+    # rather than silently saved and failing at generation time.
+    await db.flush()
+    config = await get_ai_provider_config(db)
+    try:
+        await validate_ai_config(config)
+    except HTTPException:
+        await db.rollback()
+        raise
+
     await db.commit()
     return await get_ai_settings_payload(db)
 
@@ -524,6 +535,247 @@ def _post_json(url: str, payload: dict, headers: dict[str, str]) -> dict:
         body = exc.read().decode("utf-8", errors="ignore")
         logger.warning("AI provider HTTP error %s for %s: %s", exc.code, url, body)
         raise
+
+
+def _get_json(url: str, headers: dict[str, str]) -> dict:
+    request = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="ignore")
+        logger.warning("AI provider HTTP error %s for %s: %s", exc.code, url, body)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Model discovery — list available models per provider for the Settings dropdown
+# ---------------------------------------------------------------------------
+
+def _list_gemini_models(config: AIProviderConfig) -> list[dict]:
+    # REST ListModels (consistent with the other providers, avoids SDK pager
+    # ambiguity). It reports generateContent support; the interactions API used
+    # for generation accepts a subset, so validate-on-save is the backstop.
+    url = (
+        "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1000&key="
+        + urllib.parse.quote(config.gemini_api_key, safe="")
+    )
+    data = _get_json(url, {"Content-Type": "application/json"})
+    models = []
+    for m in data.get("models", []):
+        name = m.get("name", "")
+        if not name.startswith("models/"):
+            continue
+        model_id = name[len("models/"):]
+        if "gemini" not in model_id:
+            continue
+        if "generateContent" not in (m.get("supportedGenerationMethods") or []):
+            continue
+        models.append({"id": model_id, "label": m.get("displayName") or model_id})
+    return models
+
+
+def _list_openai_models(config: AIProviderConfig) -> list[dict]:
+    headers = {"Authorization": f"Bearer {config.openai_api_key}"}
+    if config.openai_organization:
+        headers["OpenAI-Organization"] = config.openai_organization
+    if config.openai_project:
+        headers["OpenAI-Project"] = config.openai_project
+    data = _get_json("https://api.openai.com/v1/models", headers)
+    skip = (
+        "embedding", "whisper", "tts", "dall-e", "audio",
+        "image", "moderation", "realtime", "transcribe",
+    )
+    models = []
+    for m in data.get("data", []):
+        model_id = m.get("id", "")
+        if not model_id or any(tok in model_id for tok in skip):
+            continue
+        if not (
+            model_id.startswith("gpt")
+            or model_id.startswith("o")
+            or model_id.startswith("chatgpt")
+        ):
+            continue
+        models.append({"id": model_id, "label": model_id})
+    return models
+
+
+def _list_anthropic_models(config: AIProviderConfig) -> list[dict]:
+    headers = {
+        "x-api-key": config.anthropic_api_key,
+        "anthropic-version": "2023-06-01",
+    }
+    data = _get_json("https://api.anthropic.com/v1/models?limit=1000", headers)
+    models = []
+    for m in data.get("data", []):
+        model_id = m.get("id", "")
+        if model_id:
+            models.append({"id": model_id, "label": m.get("display_name") or model_id})
+    return models
+
+
+def _list_ollama_models(config: AIProviderConfig) -> list[dict]:
+    base_url = _validate_ollama_base_url(config.ollama_base_url).rstrip("/")
+    data = _get_json(f"{base_url}/api/tags", {"Content-Type": "application/json"})
+    models = []
+    for m in data.get("models", []):
+        name = m.get("name") or m.get("model")
+        if name:
+            models.append({"id": name, "label": name})
+    return models
+
+
+async def list_provider_models(config: AIProviderConfig) -> list[dict]:
+    provider = config.provider
+    secret_field = _PROVIDER_REQUIRED_SECRET_FIELD.get(provider)
+    if secret_field and not getattr(config, secret_field, "").strip():
+        raise HTTPException(
+            status_code=400,
+            detail="Enter or save an API key first to load available models.",
+        )
+    try:
+        if provider == "gemini":
+            models = await asyncio.to_thread(_list_gemini_models, config)
+        elif provider == "openai":
+            models = await asyncio.to_thread(_list_openai_models, config)
+        elif provider == "anthropic":
+            models = await asyncio.to_thread(_list_anthropic_models, config)
+        elif provider == "ollama":
+            models = await asyncio.to_thread(_list_ollama_models, config)
+        else:
+            raise HTTPException(status_code=400, detail="Unsupported AI provider")
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Listing models failed for provider %s", provider)
+        raise _map_ai_provider_error(provider, exc)
+    models.sort(key=lambda m: m["id"])
+    return models
+
+
+async def list_models_for_request(db: AsyncSession, body) -> list[dict]:
+    """List models for a provider, using a request-supplied (possibly unsaved)
+    key when present, else the saved/env key. Lets the Settings UI load models
+    with a freshly-typed key before it's persisted."""
+    provider = body.provider.strip().lower()
+    if provider not in SUPPORTED_AI_PROVIDERS:
+        raise HTTPException(status_code=400, detail="Unsupported AI provider")
+    base = await get_ai_provider_config(db)
+    config = AIProviderConfig(
+        provider=provider,
+        model=base.model,
+        gemini_api_key=(body.gemini_api_key or base.gemini_api_key or "").strip(),
+        openai_api_key=(body.openai_api_key or base.openai_api_key or "").strip(),
+        anthropic_api_key=(body.anthropic_api_key or base.anthropic_api_key or "").strip(),
+        openai_organization=(
+            body.openai_organization
+            if body.openai_organization is not None
+            else base.openai_organization
+        ),
+        openai_project=(
+            body.openai_project
+            if body.openai_project is not None
+            else base.openai_project
+        ),
+        ollama_base_url=(body.ollama_base_url or base.ollama_base_url or DEFAULT_OLLAMA_BASE_URL),
+    )
+    return await list_provider_models(config)
+
+
+# ---------------------------------------------------------------------------
+# Validate-on-save — probe the chosen provider+model so a broken config is
+# never persisted (the only reliable check that a model works with the API).
+# ---------------------------------------------------------------------------
+
+async def _probe_gemini(config: AIProviderConfig) -> None:
+    from google import genai
+
+    client = genai.Client(api_key=config.gemini_api_key)
+    # Mirror the generation call shape (interactions API) with a tiny request.
+    await client.aio.interactions.create(
+        model=config.model,
+        input="ping",
+        system_instruction="Reply with a short JSON object.",
+        response_format={
+            "type": "text",
+            "mime_type": "application/json",
+            "schema": {
+                "type": "object",
+                "properties": {"ok": {"type": "string"}},
+                "required": ["ok"],
+            },
+        },
+        generation_config={"max_output_tokens": 64, "thinking_level": "low"},
+    )
+
+
+def _probe_openai(config: AIProviderConfig) -> None:
+    headers = {
+        "Authorization": f"Bearer {config.openai_api_key}",
+        "Content-Type": "application/json",
+    }
+    if config.openai_organization:
+        headers["OpenAI-Organization"] = config.openai_organization
+    if config.openai_project:
+        headers["OpenAI-Project"] = config.openai_project
+    _post_json(
+        "https://api.openai.com/v1/responses",
+        {"model": config.model, "input": "ping", "max_output_tokens": 16},
+        headers,
+    )
+
+
+def _probe_anthropic(config: AIProviderConfig) -> None:
+    _post_json(
+        "https://api.anthropic.com/v1/messages",
+        {
+            "model": config.model,
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": "ping"}],
+        },
+        {
+            "x-api-key": config.anthropic_api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+    )
+
+
+def _probe_ollama(config: AIProviderConfig) -> None:
+    base_url = _validate_ollama_base_url(config.ollama_base_url).rstrip("/")
+    _post_json(
+        f"{base_url}/api/chat",
+        {
+            "model": config.model,
+            "stream": False,
+            "messages": [{"role": "user", "content": "ping"}],
+        },
+        {"Content-Type": "application/json"},
+    )
+
+
+async def validate_ai_config(config: AIProviderConfig) -> None:
+    """Probe the configured provider+model; raise a mapped HTTPException on
+    failure so we never persist a config that will 502 at generation time."""
+    if not config.is_configured:
+        return
+    try:
+        if config.provider == "gemini":
+            await _probe_gemini(config)
+        elif config.provider == "openai":
+            await asyncio.to_thread(_probe_openai, config)
+        elif config.provider == "anthropic":
+            await asyncio.to_thread(_probe_anthropic, config)
+        elif config.provider == "ollama":
+            await asyncio.to_thread(_probe_ollama, config)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "AI config validation failed for provider %s: %s", config.provider, exc
+        )
+        raise _map_ai_provider_error(config.provider, exc)
 
 
 def _map_ai_provider_error(provider: str, exc: Exception) -> HTTPException:

--- a/backend/services/ai_provider.py
+++ b/backend/services/ai_provider.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_PROVIDER = "gemini"
 DEFAULT_MODELS = {
-    "gemini": "gemini-3.5-flash",
+    "gemini": "gemini-flash-latest",
     "openai": "gpt-5.5-mini",
     "anthropic": "claude-sonnet-4-5",
     "ollama": "gemma3",
@@ -534,6 +534,11 @@ def _map_ai_provider_error(provider: str, exc: Exception) -> HTTPException:
             return HTTPException(
                 status_code=503,
                 detail="Gemini quota exceeded. Update the Gemini key/project or switch providers.",
+            )
+        if "not supported" in lower or "model family" in lower:
+            return HTTPException(
+                status_code=503,
+                detail="The configured Gemini model isn't supported. Choose a current model (e.g. gemini-flash-latest) in Family Settings → AI Quest Generation.",
             )
         if "404" in text and "no longer available" in lower:
             return HTTPException(

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -238,6 +238,9 @@ export default function Settings() {
     openai_api_key: '',
     anthropic_api_key: '',
   });
+  const [aiModels, setAiModels] = useState([]);
+  const [aiModelsLoading, setAiModelsLoading] = useState(false);
+  const [aiModelsMsg, setAiModelsMsg] = useState('');
 
   const fetchDashboardToken = useCallback(async () => {
     try {
@@ -380,6 +383,37 @@ export default function Settings() {
 
   const updateAiSecretInput = (key, value) => {
     setAiSecretInputs((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const loadAiModels = async () => {
+    if (!aiSettings) return;
+    setAiModelsLoading(true);
+    setAiModelsMsg('');
+    try {
+      const data = await api('/api/admin/settings/ai/models', {
+        method: 'POST',
+        body: {
+          provider: aiSettings.provider,
+          // Send freshly-typed (unsaved) keys so models load before saving.
+          gemini_api_key: aiSecretInputs.gemini_api_key || null,
+          openai_api_key: aiSecretInputs.openai_api_key || null,
+          anthropic_api_key: aiSecretInputs.anthropic_api_key || null,
+          openai_organization: aiSettings.openai_organization || null,
+          openai_project: aiSettings.openai_project || null,
+          ollama_base_url: aiSettings.ollama_base_url || null,
+        },
+      });
+      const models = Array.isArray(data.models) ? data.models : [];
+      setAiModels(models);
+      setAiModelsMsg(
+        models.length ? `Loaded ${models.length} models.` : 'No models returned.'
+      );
+    } catch (err) {
+      setAiModels([]);
+      setAiModelsMsg(err.message || 'Could not load models.');
+    } finally {
+      setAiModelsLoading(false);
+    }
   };
 
   const saveAiSettings = async () => {
@@ -601,6 +635,9 @@ export default function Settings() {
                           'model',
                           aiSettings.providers?.[nextProvider]?.default_model || ''
                         );
+                        // Model list is provider-specific — reset it.
+                        setAiModels([]);
+                        setAiModelsMsg('');
                       }}
                       className="field-input"
                     >
@@ -611,12 +648,34 @@ export default function Settings() {
                   </div>
                   <div>
                     <label className="block text-cream text-sm mb-1">Model</label>
-                    <input
-                      type="text"
-                      value={aiSettings.model || ''}
-                      onChange={(e) => updateAiSetting('model', e.target.value)}
-                      className="field-input"
-                    />
+                    <div className="flex gap-2">
+                      <input
+                        type="text"
+                        list="ai-model-options"
+                        value={aiSettings.model || ''}
+                        onChange={(e) => updateAiSetting('model', e.target.value)}
+                        placeholder="Pick from the list or type a model id"
+                        className="field-input flex-1"
+                      />
+                      <button
+                        type="button"
+                        onClick={loadAiModels}
+                        disabled={aiModelsLoading}
+                        className="game-btn game-btn-blue whitespace-nowrap"
+                      >
+                        {aiModelsLoading ? 'Loading…' : 'Load models'}
+                      </button>
+                    </div>
+                    <datalist id="ai-model-options">
+                      {aiModels.map((m) => (
+                        <option key={m.id} value={m.id}>
+                          {m.label && m.label !== m.id ? m.label : m.id}
+                        </option>
+                      ))}
+                    </datalist>
+                    {aiModelsMsg && (
+                      <p className="text-muted text-xs mt-1">{aiModelsMsg}</p>
+                    )}
                   </div>
                 </div>
 

--- a/tests/unit/test_ai_provider_settings.py
+++ b/tests/unit/test_ai_provider_settings.py
@@ -18,6 +18,17 @@ from backend.schemas import AISettingsUpdate
 from tests.unit.conftest import make_category, make_user
 
 
+@pytest.fixture(autouse=True)
+def _skip_live_validation(monkeypatch):
+    """save_ai_settings now probes the live provider; no-op it by default so
+    settings tests don't make network calls. Tests that exercise validation
+    re-patch the probe functions explicitly."""
+    async def _ok(config):
+        return None
+
+    monkeypatch.setattr("backend.services.ai_provider.validate_ai_config", _ok)
+
+
 @pytest.mark.asyncio
 async def test_ai_settings_save_encrypts_secret_and_masks_response(db):
     await make_user(db, "settings_parent1", role=UserRole.parent)
@@ -167,3 +178,78 @@ def test_default_gemini_model_is_a_supported_family():
     # gemini-2.0-* is rejected by the interactions API; the default must not be it.
     assert DEFAULT_MODELS["gemini"] == "gemini-flash-latest"
     assert not DEFAULT_MODELS["gemini"].startswith("gemini-2.0")
+
+
+def test_default_anthropic_model_is_current():
+    # claude-sonnet-4-5 is older; default should be a current model.
+    assert DEFAULT_MODELS["anthropic"] == "claude-haiku-4-5"
+
+
+@pytest.mark.asyncio
+async def test_list_models_for_request_anthropic(db, monkeypatch):
+    from backend.services import ai_provider
+    from backend.schemas import AIModelListRequest
+
+    captured = {}
+
+    def fake_get_json(url, headers):
+        captured["url"] = url
+        captured["headers"] = headers
+        return {
+            "data": [
+                {"id": "claude-haiku-4-5", "display_name": "Claude Haiku 4.5"},
+                {"id": "claude-sonnet-4-6", "display_name": "Claude Sonnet 4.6"},
+            ]
+        }
+
+    monkeypatch.setattr(ai_provider, "_get_json", fake_get_json)
+
+    models = await ai_provider.list_models_for_request(
+        db,
+        AIModelListRequest(provider="anthropic", anthropic_api_key="sk-ant-test"),
+    )
+
+    ids = [m["id"] for m in models]
+    assert ids == ["claude-haiku-4-5", "claude-sonnet-4-6"]  # sorted by id
+    assert models[0]["label"] == "Claude Haiku 4.5"
+    assert captured["headers"]["x-api-key"] == "sk-ant-test"
+
+
+@pytest.mark.asyncio
+async def test_list_models_requires_a_key(db):
+    from backend.services import ai_provider
+    from backend.schemas import AIModelListRequest
+
+    with pytest.raises(HTTPException) as exc_info:
+        await ai_provider.list_models_for_request(
+            db, AIModelListRequest(provider="openai")
+        )
+    assert exc_info.value.status_code == 400
+    assert "API key" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_save_ai_settings_rejects_unvalidatable_model(db, monkeypatch):
+    # Override the autouse no-op: make validation fail like an unsupported model.
+    from backend.services import ai_provider
+
+    async def _boom(config):
+        raise ai_provider._map_ai_provider_error(
+            "gemini", RuntimeError("400 Model family gemini-2.0 is not supported.")
+        )
+
+    monkeypatch.setattr(ai_provider, "validate_ai_config", _boom)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await save_ai_settings(
+            db,
+            AISettingsUpdate(
+                provider="gemini",
+                model="gemini-2.0-flash",
+                gemini_api_key="test-key",
+            ),
+        )
+    assert exc_info.value.status_code == 503
+    # Nothing should have been persisted (rolled back).
+    assert await db.get(AppSetting, "ai_gemini_api_key") is None
+    assert await db.get(AppSetting, "ai_provider") is None

--- a/tests/unit/test_ai_provider_settings.py
+++ b/tests/unit/test_ai_provider_settings.py
@@ -146,3 +146,24 @@ def test_map_ai_provider_error_for_gemini_retired_model():
     )
     assert error.status_code == 503
     assert "no longer available" in error.detail.lower()
+
+
+def test_map_ai_provider_error_for_unsupported_gemini_model():
+    # The interactions API rejects unsupported model families (e.g. gemini-2.0)
+    # with a 400; surface an actionable message instead of a generic 502.
+    error = _map_ai_provider_error(
+        "gemini",
+        RuntimeError(
+            "Error code: 400 - {'error': {'message': 'Model family "
+            "gemini-2.0 is not supported.', 'code': 'invalid_request'}}"
+        ),
+    )
+    assert error.status_code == 503
+    assert "isn't supported" in error.detail
+    assert "Family Settings" in error.detail
+
+
+def test_default_gemini_model_is_a_supported_family():
+    # gemini-2.0-* is rejected by the interactions API; the default must not be it.
+    assert DEFAULT_MODELS["gemini"] == "gemini-flash-latest"
+    assert not DEFAULT_MODELS["gemini"].startswith("gemini-2.0")


### PR DESCRIPTION
Builds on the Gemini default fix to make model selection robust across **all four providers**.

## What's included
1. **Correct defaults** — Gemini `gemini-flash-latest` (interactions-compatible alias), Anthropic bumped to `claude-haiku-4-5` (current). OpenAI/Ollama defaults left as-is since the dropdown + validation now drive correctness.
2. **Clearer error** — `_map_ai_provider_error` catches the `400 / "model family not supported"` case → actionable 503 instead of *"oracle could not be reached."*
3. **Model dropdowns (all providers)** — new `POST /api/admin/settings/ai/models` lists available models per provider via each one's own endpoint:
   - Gemini: REST ListModels (`generateContent`-capable models)
   - OpenAI: `GET /v1/models` (chat models)
   - Anthropic: `GET /v1/models`
   - Ollama: `GET /api/tags` (local)
   Accepts an optional **unsaved** key so the UI loads models right after a key is typed. Settings UI uses a datalist combobox (pick-or-type) + "Load models".
4. **Validate-on-save** — `save_ai_settings` probes the chosen provider+model with a tiny request before persisting; on failure it **rolls back** and returns the mapped error. This is the reliable guarantee since "supports interactions" isn't exposed as filterable model metadata — so instead of trying to filter the dropdown, we confirm the actual choice works.

## Why validate-on-save instead of filtering the dropdown
Gemini's `models.list()` reports `generateContent` support, not whether a model works with the `interactions` API (the one used for generation). A metadata filter would be a guess; a probe is definitive and works uniformly for every provider.

## Tests — 127/127 pass
New: model listing + key-required guard, save-time validation rejection (rolls back), current-default assertions, unsupported-model error mapping.

## Notes / live-verification needed
- I can't exercise the real provider APIs without keys; provider call shapes mirror the existing generation code. Live paths to confirm on deploy: Gemini ListModels + interactions probe, OpenAI `/v1/responses` probe, Anthropic `/v1/messages` probe, Ollama `/api/chat` probe.
- Changing defaults only affects fresh installs; existing saved models are guided by the validate-on-save error + the dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)